### PR TITLE
Dockerfile for Linux amd64 binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GORELEASER_CURRENT_TAG=latest
 WORKDIR /tmp/cirrus-ci-agent
 ADD . /tmp/cirrus-ci-agent/
 
-RUN goreleaser --snapshot
+RUN goreleaser build --snapshot
 
 FROM gcr.io/distroless/base-debian10
 COPY --from=builder /tmp/cirrus-ci-agent/dist/agent_linux_amd64/agent /bin/cirrus-ci-agent

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ADD . /tmp/cirrus-ci-agent/
 RUN goreleaser --snapshot
 
 FROM gcr.io/distroless/base-debian10
-COPY --from=builder /tmp/cirrus-ci-agent/ /bin
+COPY --from=builder /tmp/cirrus-ci-agent/dist/agent_linux_amd64/agent /bin/cirrus-ci-agent

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM goreleaser/goreleaser:latest as builder
+
+ENV GORELEASER_CURRENT_TAG=latest
+
+WORKDIR /tmp/cirrus-ci-agent
+ADD . /tmp/cirrus-ci-agent/
+
+RUN goreleaser --snapshot
+
+FROM gcr.io/distroless/base-debian10
+COPY --from=builder /tmp/cirrus-ci-agent/ /bin


### PR DESCRIPTION
Right now Cirrus CI when running tasks in Kubernetes uses an init container to download an agent executable from https://api.cirrus-ci.com/assets/linux-amd64-agent. If we'll publish a docker image then we'll be able to cache the binary on Kubernetes nodes directly instead of relying on a CDN.