### PR TITLE
Release uncompressed binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,9 @@ project_name: agent
 before:
   hooks:
     - go mod download
+    
+archives:
+  format: binary
 
 builds:
   - main: cmd/agent/main.go


### PR DESCRIPTION
Not all environments which will download the release artifacts will have a tool to unzip and unarchive the `*.tar.gz` files. Let's just publish the raw binaries. Plus I think GitHub's CDN will zip the files if a client accepts gzip.