### PR TITLE
Parse API endpoint protocol

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -25,8 +25,7 @@ import (
 )
 
 func main() {
-	apiEndpointPtr := flag.String("api-endpoint", "grpc.cirrus-ci.com:443", "GRPC endpoint")
-	insecure := flag.Bool("insecure-endpoint", false, "Do not use TLS when connecting over GRPC")
+	apiEndpointPtr := flag.String("api-endpoint", "https://grpc.cirrus-ci.com:443", "GRPC endpoint URL")
 	taskIdPtr := flag.Int64("task-id", 0, "Task ID")
 	clientTokenPtr := flag.String("client-token", "", "Secret token")
 	serverTokenPtr := flag.String("server-token", "", "Secret token")
@@ -51,7 +50,7 @@ func main() {
 
 	var conn *grpc.ClientConn
 	for {
-		newConnection, err := dialWithTimeout(apiEndpointPtr, *insecure)
+		newConnection, err := dialWithTimeout(*apiEndpointPtr)
 		if err == nil {
 			conn = newConnection
 			log.Printf("Connected!\n")
@@ -146,24 +145,25 @@ func main() {
 	}
 }
 
-func dialWithTimeout(apiEndpointPtr *string, insecure bool) (*grpc.ClientConn, error) {
+func dialWithTimeout(apiEndpoint string) (*grpc.ClientConn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	// Use TLS by default
-	tlsCredentials := credentials.NewTLS(&tls.Config{
-		MinVersion: tls.VersionTLS13,
-	})
-	transportSecurity := grpc.WithTransportCredentials(tlsCredentials)
+	// insecure by default because we can run it on localhost or in a private network
+	transportSecurity := grpc.WithInsecure()
 
-	// Fall back to plain mode without TLS when explicitly asked to
-	if insecure {
-		transportSecurity = grpc.WithInsecure()
+	// Use TLS if explicitly asked or no schema is in the target
+	if strings.Contains(apiEndpoint, "https://") || !strings.Contains(apiEndpoint, "://") {
+		tlsCredentials := credentials.NewTLS(&tls.Config{
+			MinVersion: tls.VersionTLS13,
+		})
+		transportSecurity = grpc.WithTransportCredentials(tlsCredentials)
 	}
 
 	return grpc.DialContext(
 		ctx,
-		*apiEndpointPtr,
+		// sanitize but leave unix:// if presented
+		strings.TrimPrefix(strings.TrimPrefix(apiEndpoint, "http://"), "https://"),
 		grpc.WithBlock(),
 		transportSecurity,
 		grpc.WithUnaryInterceptor(

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -173,7 +173,7 @@ func dialWithTimeout(apiEndpoint string) (*grpc.ClientConn, error) {
 }
 
 func transportSettings(apiEndpoint string) (string, bool) {
-	// insecure by default because we can run it on localhost or in a private network
+	// Insecure by default to preserve backwards compatibility
 	insecure := true
 
 	// Use TLS if explicitly asked or no schema is in the target

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/client"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_DialHTTPS(t *testing.T) {
+	assert.Nil(t, checkEndpoint(t, "https://grpc.cirrus-ci.com:443"))
+}
+
+func Test_DialNoSchema(t *testing.T) {
+	assert.Nil(t, checkEndpoint(t, "grpc.cirrus-ci.com:443"))
+}
+
+func checkEndpoint(t *testing.T, endpoint string) error {
+	clientConn, err := dialWithTimeout(endpoint)
+	if err != nil {
+		return err
+	}
+
+	defer clientConn.Close()
+
+	client.InitClient(clientConn)
+	_, err = client.CirrusClient.Ping(context.Background(), &empty.Empty{})
+	return err
+}

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -8,15 +8,33 @@ import (
 	"testing"
 )
 
+func Test_SecurityDefault(t *testing.T) {
+	target, insecure := transportSettings("grpc.cirrus-ci.com:443")
+	assert.Equal(t, "grpc.cirrus-ci.com:443", target)
+	assert.False(t, insecure)
+}
+
+func Test_SecurityHTTP(t *testing.T) {
+	target, insecure := transportSettings("http://grpc.cirrus-ci.com:80")
+	assert.Equal(t, "grpc.cirrus-ci.com:80", target)
+	assert.True(t, insecure)
+}
+
+func Test_SecurityUNIX(t *testing.T) {
+	target, insecure := transportSettings("unix:///agent.sock")
+	assert.Equal(t, "unix:///agent.sock", target)
+	assert.True(t, insecure)
+}
+
 func Test_DialHTTPS(t *testing.T) {
-	assert.Nil(t, checkEndpoint(t, "https://grpc.cirrus-ci.com:443"))
+	assert.Nil(t, checkEndpoint("https://grpc.cirrus-ci.com:443"))
 }
 
 func Test_DialNoSchema(t *testing.T) {
-	assert.Nil(t, checkEndpoint(t, "grpc.cirrus-ci.com:443"))
+	assert.Nil(t, checkEndpoint("grpc.cirrus-ci.com:443"))
 }
 
-func checkEndpoint(t *testing.T, endpoint string) error {
+func checkEndpoint(endpoint string) error {
 	clientConn, err := dialWithTimeout(endpoint)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	github.com/joshdk/go-junit v0.0.0-20200702055522-6efcf4050909 // indirect
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -186,5 +188,7 @@ gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRN
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Let's parse protocol from the endpoint if possible instead of introducing yet another flag. It will be easier to integrate with tooling: you'll need to change one flag instead if one or two.