### PR TITLE
Ensure that WaitForLocalPort() will exit as early as possible

### DIFF
--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -14,9 +14,7 @@ func WaitForLocalPort(port int, waitDuration time.Duration) {
 			time.Sleep(1 * time.Second)
 			continue
 		}
-		if conn != nil {
-			_ = conn.Close()
-		}
+		_ = conn.Close()
 		break
 	}
 }

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -17,5 +17,6 @@ func WaitForLocalPort(port int, waitDuration time.Duration) {
 		if conn != nil {
 			_ = conn.Close()
 		}
+		break
 	}
 }

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -1,0 +1,32 @@
+package network_test
+
+import (
+	"github.com/cirruslabs/cirrus-ci-agent/internal/network"
+	"github.com/stretchr/testify/assert"
+	"net"
+	"testing"
+	"time"
+)
+
+const (
+	maxAllowedWaitTime  = 60 * time.Second
+	maxExpectedWaitTime = 10 * time.Second
+)
+
+// TestEarlyExit ensures that WaitForLocalPort() will exit before the full waitDuration
+// if the port becomes available in the first loop iteration.
+func TestEarlyExit(t *testing.T) {
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lis.Close()
+
+	port := lis.Addr().(*net.TCPAddr).Port
+
+	start := time.Now()
+	network.WaitForLocalPort(port, maxAllowedWaitTime)
+	stop := time.Now()
+
+	assert.WithinDuration(t, stop, start, maxExpectedWaitTime)
+}


### PR DESCRIPTION
No need to wait for the full `waitDuration` if we've already established a connection once.