### PR TITLE
Add rsync to ignore .gitignore files when populating working directory

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,6 +15,7 @@ task:
 
 docker_builder:
   name: Test Docker Build
+  only_if: "changesInclude('Dockerfile')"
   build_script: docker build .
 
 task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,11 @@ task:
   get_script: go get ./...
   build_script: go build ./...
   test_script: go test ./...
-  
+
+docker_builder:
+  name: Test Docker Build
+  build_script: docker build .
+
 task:
   name: Build Binaries
   only_if: $CIRRUS_PR != ''
@@ -26,7 +30,9 @@ task:
 task:
   name: Release
   only_if: $CIRRUS_TAG != ''
-  depends_on: Test
+  depends_on:
+    - Test
+    - Test Docker Build
   env:
     GITHUB_TOKEN: ENCRYPTED[!98ace8259c6024da912c14d5a3c5c6aac186890a8d4819fad78f3e0c41a4e0cd3a2537dd6e91493952fb056fa434be7c!]
   container:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ ADD . /tmp/cirrus-ci-agent/
 RUN goreleaser build --snapshot
 
 FROM alpine:latest
+
+RUN apk add --no-cache rsync
 COPY --from=builder /tmp/cirrus-ci-agent/dist/agent_linux_amd64/agent /bin/cirrus-ci-agent


### PR DESCRIPTION
Another option is to copy a statically linked rsync binary along with the agent's binary and call rsync from the context of task's container.