### PR TITLE
HTTP cache: don't re-recreate the Listener

### DIFF
--- a/internal/http_cache/http_cache.go
+++ b/internal/http_cache/http_cache.go
@@ -27,9 +27,8 @@ func Start(taskIdentification api.TaskIdentification) string {
 	}
 	if err == nil {
 		address = listener.Addr().String()
-		listener.Close()
 		log.Printf("Starting http cache server %s\n", address)
-		go http.ListenAndServe(address, nil)
+		go http.Serve(listener, nil)
 	} else {
 		log.Printf("Failed to start http cache server %s: %s\n", address, err)
 	}


### PR DESCRIPTION
This drastically decreases the number of "connection refused" errors caused by races when the HTTP server in a separate goroutine is not started, yet the agent already tries to use it.

Real-world example: https://cirrus-ci.com/task/4627810209759232?command=test#L326