### PR TITLE
Ensure working directory exists

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -85,6 +85,7 @@ func (executor *Executor) RunBuild() {
 
 	environment := getExpandedScriptEnvironment(executor, response.Environment)
 
+	EnsureFolderExists(environment["CIRRUS_WORKING_DIR"])
 	os.Chdir(environment["CIRRUS_WORKING_DIR"])
 
 	commands := response.Commands


### PR DESCRIPTION
I wonder if we can also enforce the `CIRRUS_WORKING_DIR` environment variable existence and throw an error if it doesn't set.