### PR TITLE
Populate hasher after unarchiving the cache

### DIFF
--- a/internal/executor/cache.go
+++ b/internal/executor/cache.go
@@ -67,17 +67,10 @@ func DownloadCache(executor *Executor, commandName string, cacheHost string, ins
 		return false
 	}
 
-	usedGlob := pathLooksLikeGlob(folderToCache)
-	baseFolder := folderToCache
-	if usedGlob {
-		baseFolder = custom_env["CIRRUS_WORKING_DIR"]
-	}
-
-	cachePopulated, cacheAvailable := tryToDownloadAndPopulateCache(logUploader, commandName, cacheHost, cacheKey, baseFolder)
-
 	var glob string
-	foldersToCache := []string{folderToCache}
-	if usedGlob {
+	baseFolder := folderToCache
+	if pathLooksLikeGlob(folderToCache) {
+		baseFolder = custom_env["CIRRUS_WORKING_DIR"]
 		glob = folderToCache
 
 		// Sanity check
@@ -101,7 +94,12 @@ func DownloadCache(executor *Executor, commandName string, cacheHost string, ins
 				glob, terminatedWorkingDir)))
 			return false
 		}
+	}
 
+	cachePopulated, cacheAvailable := tryToDownloadAndPopulateCache(logUploader, commandName, cacheHost, cacheKey, baseFolder)
+
+	foldersToCache := []string{folderToCache}
+	if glob != "" {
 		// Expand the glob so we can calculate the hashes for directories that already exist
 		foldersToCache, err = doublestar.Glob(glob)
 		if err != nil {

--- a/internal/executor/cache.go
+++ b/internal/executor/cache.go
@@ -113,7 +113,7 @@ func DownloadCache(executor *Executor, commandName string, cacheHost string, ins
 	fileHasher := hasher.New()
 	if cachePopulated {
 		for _, folderToCache := range foldersToCache {
-			if err := fileHasher.AddFolder(folderToCache); err != nil {
+			if err := fileHasher.AddFolder(baseFolder, folderToCache); err != nil {
 				logUploader.Write([]byte(fmt.Sprintf("\nFailed to calculate hash of %s! %s", folderToCache, err)))
 			}
 		}
@@ -293,7 +293,7 @@ func UploadCache(executor *Executor, commandName string, cacheHost string, instr
 
 	fileHasher := hasher.New()
 	for _, folder := range cache.FoldersToCache {
-		if err := fileHasher.AddFolder(folder); err != nil {
+		if err := fileHasher.AddFolder(cache.BaseFolder, folder); err != nil {
 			logUploader.Write([]byte(fmt.Sprintf("Failed to calculate hash of %s! %s", folder, err)))
 			logUploader.Write([]byte("Skipping uploading of cache!"))
 			return true

--- a/internal/executor/cache.go
+++ b/internal/executor/cache.go
@@ -69,8 +69,8 @@ func DownloadCache(executor *Executor, commandName string, cacheHost string, ins
 
 	var glob string
 	baseFolder := folderToCache
+	foldersToCache := []string{folderToCache}
 	if pathLooksLikeGlob(folderToCache) {
-		baseFolder = custom_env["CIRRUS_WORKING_DIR"]
 		glob = folderToCache
 
 		// Sanity check
@@ -98,8 +98,8 @@ func DownloadCache(executor *Executor, commandName string, cacheHost string, ins
 
 	cachePopulated, cacheAvailable := tryToDownloadAndPopulateCache(logUploader, commandName, cacheHost, cacheKey, baseFolder)
 
-	foldersToCache := []string{folderToCache}
 	if glob != "" {
+		baseFolder = custom_env["CIRRUS_WORKING_DIR"]
 		// Expand the glob so we can calculate the hashes for directories that already exist
 		foldersToCache, err = doublestar.Glob(glob)
 		if err != nil {

--- a/internal/hasher/hasher.go
+++ b/internal/hasher/hasher.go
@@ -79,11 +79,7 @@ func (hasher *Hasher) DiffWithNewer(newer *Hasher) []DiffEntry {
 	return result
 }
 
-func (hasher *Hasher) AddFolder(folderPath string) error {
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return err
-	}
+func (hasher *Hasher) AddFolder(baseFolder string, folderPath string) error {
 	if _, err := os.Stat(folderPath); os.IsNotExist(err) {
 		return nil
 	}
@@ -110,7 +106,7 @@ func (hasher *Hasher) AddFolder(folderPath string) error {
 		if err != nil {
 			return err
 		}
-		relativePath, err := filepath.Rel(workingDir, path)
+		relativePath, err := filepath.Rel(baseFolder, path)
 		if err != nil {
 			return err
 		}

--- a/internal/hasher/hasher.go
+++ b/internal/hasher/hasher.go
@@ -80,10 +80,14 @@ func (hasher *Hasher) DiffWithNewer(newer *Hasher) []DiffEntry {
 }
 
 func (hasher *Hasher) AddFolder(folderPath string) error {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
 	if _, err := os.Stat(folderPath); os.IsNotExist(err) {
 		return nil
 	}
-	err := filepath.Walk(folderPath, func(path string, info os.FileInfo, err error) error {
+	return filepath.Walk(folderPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -106,7 +110,7 @@ func (hasher *Hasher) AddFolder(folderPath string) error {
 		if err != nil {
 			return err
 		}
-		relativePath, err := filepath.Rel(folderPath, path)
+		relativePath, err := filepath.Rel(workingDir, path)
 		if err != nil {
 			return err
 		}
@@ -114,11 +118,6 @@ func (hasher *Hasher) AddFolder(folderPath string) error {
 		_, err = hasher.globalHash.Write(fileHash)
 		return err
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func fileHash(path string) ([]byte, error) {

--- a/internal/hasher/hasher_test.go
+++ b/internal/hasher/hasher_test.go
@@ -97,7 +97,7 @@ func TestDiffWithNewer(t *testing.T) {
 			}
 
 			newHasher := hasher.New()
-			if err := newHasher.AddFolder(oldDir, newDir); err != nil {
+			if err := newHasher.AddFolder(newDir, newDir); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/hasher/hasher_test.go
+++ b/internal/hasher/hasher_test.go
@@ -92,12 +92,12 @@ func TestDiffWithNewer(t *testing.T) {
 
 			// Hash directories
 			oldHasher := hasher.New()
-			if err := oldHasher.AddFolder(oldDir); err != nil {
+			if err := oldHasher.AddFolder(oldDir, oldDir); err != nil {
 				t.Fatal(err)
 			}
 
 			newHasher := hasher.New()
-			if err := newHasher.AddFolder(newDir); err != nil {
+			if err := newHasher.AddFolder(oldDir, newDir); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
Tested with this integration test:

```yaml
container:
  image: alpine:latest

task:
  clone_script: echo 'clone'
  cache:
    name: glob
    folder: "**/cache"
    fingerprint_script: echo 'fingerprint!'
    reupload_on_changes: true
    populate_script:
      - mkdir -p cache
      - echo 'foo' >> cache/foo.txt
      - mkdir -p bar/cache
  dirty_script: echo $CIRRUS_TASK_ID >> bar/cache/bar.txt
  verify_script: cat cache/foo.txt bar/cache/bar.txt
```