### PR TITLE
Create agent logs in $TMP

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -42,7 +42,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	logFilePath := filepath.Join(os.TempDir(), "cirrus-agent.log")
+	logFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("cirrus-agent-%d.log", *taskIdPtr))
 	defer uploadAgentLogs(logFilePath, *taskIdPtr, *clientTokenPtr)
 
 	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0660)
@@ -150,7 +150,10 @@ func uploadAgentLogs(logFilePath string, taskId int64, clientToken string) {
 		TaskIdentification: &taskIdentification,
 		Logs:               string(logContents),
 	}
-	client.CirrusClient.ReportAgentLogs(context.Background(), &request)
+	_, err := client.CirrusClient.ReportAgentLogs(context.Background(), &request)
+	if err == nil {
+		os.Remove(logFilePath)
+	}
 }
 
 func dialWithTimeout(apiEndpoint string) (*grpc.ClientConn, error) {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -43,13 +43,9 @@ func main() {
 	}
 
 	logFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("cirrus-agent-%d.log", *taskIdPtr))
-	defer uploadAgentLogs(logFilePath, *taskIdPtr, *clientTokenPtr)
-
 	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0660)
 	if err != nil {
 		log.Printf("Failed to create log file: %v", err)
-	} else {
-		defer logFile.Close()
 	}
 	multiWriter := io.MultiWriter(logFile, os.Stdout)
 	log.SetOutput(multiWriter)
@@ -135,6 +131,9 @@ func main() {
 
 	buildExecutor := executor.NewExecutor(*taskIdPtr, *clientTokenPtr, *serverTokenPtr, *commandFromPtr, *commandToPtr)
 	buildExecutor.RunBuild()
+
+	logFile.Close()
+	uploadAgentLogs(logFilePath, *taskIdPtr, *clientTokenPtr)
 }
 
 func uploadAgentLogs(logFilePath string, taskId int64, clientToken string) {


### PR DESCRIPTION
Also made it always override the file (useful for persistent workers). Plus refactored how logs are reported (via defer).