### PR TITLE
Fix NPE on script timeout

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -203,7 +203,7 @@ func (executor *Executor) performStep(env map[string]string, currentStep *api.Co
 	case *api.Command_ScriptInstruction:
 		cmd, err := executor.ExecuteScriptsStreamLogsAndWait(currentStep.Name, instruction.ScriptInstruction.Scripts, env)
 		success = err == nil && cmd.ProcessState.Success()
-		if cmd != nil {
+		if err == nil {
 			if ws, ok := cmd.ProcessState.Sys().(syscall.WaitStatus); ok {
 				signaledToExit = ws.Signaled()
 			}


### PR DESCRIPTION
When the agent runs a script that [exceeds the timeout](https://cirrus-ci.org/faq/#instance-timed-out) it kills it with `cmd.Process.Kill()`, which [causes `Cmd`'s `ProcessState` field to be `nil`](https://golang.org/pkg/os/exec/#Cmd):

>ProcessState contains information about an exited process, available after a call to Wait or Run.

Ensure that we only retrieve ProcessState of a properly terminated `Cmd`.