### PR TITLE
Use task's environment when initializing LogUploader

### DIFF
--- a/internal/executor/artifacts.go
+++ b/internal/executor/artifacts.go
@@ -17,7 +17,7 @@ import (
 )
 
 func UploadArtifacts(executor *Executor, name string, artifactsInstruction *api.ArtifactsInstruction, customEnv map[string]string) bool {
-	logUploader, err := NewLogUploader(executor, name)
+	logUploader, err := NewLogUploader(executor, name, customEnv)
 	if err != nil {
 		request := api.ReportAgentProblemRequest{
 			TaskIdentification: executor.taskIdentification,

--- a/internal/executor/cache.go
+++ b/internal/executor/cache.go
@@ -36,7 +36,7 @@ var httpClient = &http.Client{
 }
 
 func DownloadCache(executor *Executor, commandName string, cacheHost string, instruction *api.CacheInstruction, custom_env map[string]string) bool {
-	logUploader, err := NewLogUploader(executor, commandName)
+	logUploader, err := NewLogUploader(executor, commandName, custom_env)
 	if err != nil {
 		return false
 	}
@@ -257,8 +257,8 @@ func FetchCache(logUploader *LogUploader, commandName string, cacheHost string, 
 	return cacheFile, nil
 }
 
-func UploadCache(executor *Executor, commandName string, cacheHost string, instruction *api.UploadCacheInstruction) bool {
-	logUploader, err := NewLogUploader(executor, commandName)
+func UploadCache(executor *Executor, commandName string, cacheHost string, instruction *api.UploadCacheInstruction, env map[string]string) bool {
+	logUploader, err := NewLogUploader(executor, commandName, env)
 	if err != nil {
 		return false
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -230,7 +230,7 @@ func (executor *Executor) performStep(env map[string]string, currentStep *api.Co
 	case *api.Command_CacheInstruction:
 		success = DownloadCache(executor, currentStep.Name, executor.httpCacheHost, instruction.CacheInstruction, env)
 	case *api.Command_UploadCacheInstruction:
-		success = UploadCache(executor, currentStep.Name, executor.httpCacheHost, instruction.UploadCacheInstruction)
+		success = UploadCache(executor, currentStep.Name, executor.httpCacheHost, instruction.UploadCacheInstruction, env)
 	case *api.Command_ArtifactsInstruction:
 		success = UploadArtifacts(executor, currentStep.Name, instruction.ArtifactsInstruction, env)
 	default:
@@ -260,7 +260,7 @@ func (executor *Executor) ExecuteScriptsStreamLogsAndWait(
 	commandName string,
 	scripts []string,
 	env map[string]string) (*exec.Cmd, error) {
-	logUploader, err := NewLogUploader(executor, commandName)
+	logUploader, err := NewLogUploader(executor, commandName, env)
 	if err != nil {
 		message := fmt.Sprintf("Failed to initialize command %v log upload: %v", commandName, err)
 		request := api.ReportAgentProblemRequest{
@@ -281,7 +281,7 @@ func (executor *Executor) ExecuteScriptsAndStreamLogs(
 	commandName string,
 	scripts []string,
 	env map[string]string) (*exec.Cmd, *LogUploader, error) {
-	logUploader, err := NewLogUploader(executor, commandName)
+	logUploader, err := NewLogUploader(executor, commandName, env)
 	if err != nil {
 		message := fmt.Sprintf("Failed to initialize command %v log upload: %v", commandName, err)
 		request := api.ReportAgentProblemRequest{
@@ -302,7 +302,7 @@ func (executor *Executor) CreateFile(
 	instruction *api.FileInstruction,
 	env map[string]string,
 ) bool {
-	logUploader, err := NewLogUploader(executor, commandName)
+	logUploader, err := NewLogUploader(executor, commandName, env)
 	if err != nil {
 		request := api.ReportAgentProblemRequest{
 			TaskIdentification: executor.taskIdentification,
@@ -341,7 +341,7 @@ func (executor *Executor) CreateFile(
 }
 
 func (executor *Executor) CloneRepository(env map[string]string) bool {
-	logUploader, err := NewLogUploader(executor, "clone")
+	logUploader, err := NewLogUploader(executor, "clone", env)
 	if err != nil {
 		request := api.ReportAgentProblemRequest{
 			TaskIdentification: executor.taskIdentification,

--- a/internal/executor/logs.go
+++ b/internal/executor/logs.go
@@ -36,7 +36,7 @@ type LogUploader struct {
 	mutex              sync.RWMutex
 }
 
-func NewLogUploader(executor *Executor, commandName string) (*LogUploader, error) {
+func NewLogUploader(executor *Executor, commandName string, env map[string]string) (*LogUploader, error) {
 	logClient, err := InitializeLogStreamClient(executor.taskIdentification, commandName, false)
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func NewLogUploader(executor *Executor, commandName string) (*LogUploader, error
 		valuesToMask:       executor.sensitiveValues,
 		closed:             false,
 
-		LogTimestamps: os.Getenv("CIRRUS_LOG_TIMESTAMP") == "true",
+		LogTimestamps: env["CIRRUS_LOG_TIMESTAMP"] == "true",
 		GetTimestamp:  time.Now,
 		OweTimestamp:  true,
 	}


### PR DESCRIPTION
This makes sure `CIRRUS_LOG_TIMESTAMP` gets picked up from the task's environment, since task's environment is not propagated to the system's environment available via `os.Getenv` otherwise.