### PR TITLE
Make potential bytes expansion transparent in LogUploader.Write()

### DIFF
--- a/internal/executor/logs.go
+++ b/internal/executor/logs.go
@@ -114,6 +114,9 @@ func (uploader *LogUploader) Write(bytes []byte) (int, error) {
 		return 0, nil
 	}
 
+	// Make potential bytes expansion below transparent to the caller
+	originalLen := len(bytes)
+
 	if uploader.LogTimestamps {
 		bytes = uploader.WithTimestamps(bytes)
 	}
@@ -125,7 +128,7 @@ func (uploader *LogUploader) Write(bytes []byte) (int, error) {
 		copy(bytesCopy, bytes)
 		uploader.logsChannel <- bytesCopy
 	}
-	return len(bytes), nil
+	return originalLen, nil
 }
 
 func (uploader *LogUploader) StreamLogs() {

--- a/internal/executor/shell.go
+++ b/internal/executor/shell.go
@@ -72,7 +72,8 @@ func ShellCommandsAndWait(scripts []string, custom_env *map[string]string, handl
 	case <-done:
 		if ws, ok := cmd.ProcessState.Sys().(syscall.WaitStatus); ok {
 			if ws.Signaled() {
-				handler([]byte("\nSignaled to exit!"))
+				message := fmt.Sprintf("\nSignaled to exit (%v)!", ws.Signal())
+				handler([]byte(message))
 			}
 			exitStatus := ws.ExitStatus()
 			if exitStatus > 1 {


### PR DESCRIPTION
Otherwise the caller might go astray when doing a `bytesSent != bytesWritten` comparison.