### PR TITLE
Don't override log file in stop hook

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -45,6 +45,8 @@ func main() {
 
 	logFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("cirrus-agent-%d.log", *taskIdPtr))
 	if *stopHook {
+		// In case of a failure the log file will be persisted on the machine for debugging purposes.
+		// But unfortunately stop hook invocation will override it so let's use a different name.
 		logFilePath = filepath.Join(os.TempDir(), fmt.Sprintf("cirrus-agent-%d-hook.log", *taskIdPtr))
 	}
 	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0660)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -44,6 +44,9 @@ func main() {
 	}
 
 	logFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("cirrus-agent-%d.log", *taskIdPtr))
+	if *stopHook {
+		logFilePath = filepath.Join(os.TempDir(), fmt.Sprintf("cirrus-agent-%d-hook.log", *taskIdPtr))
+	}
 	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0660)
 	if err != nil {
 		log.Printf("Failed to create log file: %v", err)
@@ -79,6 +82,9 @@ func main() {
 		_, err = client.CirrusClient.ReportStopHook(context.Background(), &request)
 		if err != nil {
 			log.Printf("Failed to report stop hook for task %d: %v\n", *taskIdPtr, err)
+		} else {
+			logFile.Close()
+			os.Remove(logFilePath)
 		}
 		os.Exit(0)
 	}


### PR DESCRIPTION
In case of a failure the log file will be persisted on the machine for debugging purposes. But unfortunately stop hook invocation will override it.