### PR TITLE
Use http client with certificates for proxying 

### DIFF
--- a/internal/executor/cache.go
+++ b/internal/executor/cache.go
@@ -224,9 +224,6 @@ func FetchCache(logUploader *LogUploader, commandName string, cacheHost string, 
 	}
 	defer cacheFile.Close()
 
-	httpClient := http.Client{
-		Timeout: 5 * time.Minute,
-	}
 	downloadStartTime := time.Now()
 	resp, err := httpClient.Get(fmt.Sprintf("http://%s/%s", cacheHost, cacheKey))
 	if err != nil {


### PR DESCRIPTION
Otherwise it's not working in some environments and users are getting constant cache misses. See https://github.com/cirruslabs/cirrus-ci-docs/issues/727#issuecomment-727255825