### PR TITLE
TransportSettings: a more finer Unix domain socket schema parsing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -92,8 +92,6 @@ apple_silicon: &APPLE_SILICON_BUILD
     - gotip version
   build_script:
     - CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 gotip build -o agent-darwin-arm64 cmd/agent/main.go
-  sign_script:
-    - codesign --sign - agent-darwin-arm64
 
 task:
   name: Release Apple Silicon (Dry Run)

--- a/pkg/grpchelper/grpchelper.go
+++ b/pkg/grpchelper/grpchelper.go
@@ -3,14 +3,20 @@ package grpchelper
 import "strings"
 
 func TransportSettings(apiEndpoint string) (string, bool) {
-	// Insecure by default to preserve backwards compatibility
-	insecure := true
-
-	// Use TLS if explicitly asked or no schema is in the target
-	if strings.Contains(apiEndpoint, "https://") || !strings.Contains(apiEndpoint, "://") {
-		insecure = false
+	// HTTP is always insecure
+	if strings.HasPrefix(apiEndpoint, "http://") {
+		return strings.TrimPrefix(apiEndpoint, "http://"), true
 	}
-	// sanitize but leave unix:// if presented
-	target := strings.TrimPrefix(strings.TrimPrefix(apiEndpoint, "http://"), "https://")
-	return target, insecure
+
+	// Unix domain sockets are always insecure
+	if strings.HasPrefix(apiEndpoint, "unix:") {
+		return apiEndpoint, true
+	}
+
+	// HTTPS and other cases are always secure
+	if strings.HasPrefix(apiEndpoint, "https://") {
+		apiEndpoint = strings.TrimPrefix(apiEndpoint, "https://")
+	}
+
+	return apiEndpoint, false
 }

--- a/pkg/grpchelper/grpchelper_test.go
+++ b/pkg/grpchelper/grpchelper_test.go
@@ -29,3 +29,9 @@ func Test_SecurityUNIX(t *testing.T) {
 	assert.Equal(t, "unix:///agent.sock", target)
 	assert.True(t, insecure)
 }
+
+func Test_SecurityUNIXWindows(t *testing.T) {
+	target, insecure := grpchelper.TransportSettings("unix:C:\\Temp\\cli.sock")
+	assert.Equal(t, "unix:C:\\Temp\\cli.sock", target)
+	assert.True(t, insecure)
+}


### PR DESCRIPTION
Needed to support Unix domain sockets on Windows properly.