### PR TITLE
Use the merged config and code for pull requests

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -407,7 +407,7 @@ func (executor *Executor) CloneRepository(env map[string]string) bool {
 			return false
 		}
 
-		refSpec := fmt.Sprintf("+refs/pull/%s/head:refs/remotes/origin/pull/%[1]s", pr_number)
+		refSpec := fmt.Sprintf("+refs/pull/%s/merge:refs/remotes/origin/pull/%[1]s", pr_number)
 		logUploader.Write([]byte(fmt.Sprintf("\nFetching %s...\n", refSpec)))
 		fetchOptions := &git.FetchOptions{
 			RemoteName: remoteConfig.Name,


### PR DESCRIPTION
Pull requests aren't always based on master, and for some projects it would be practically impossible to enforce that. While it is possible to simply merge the source code from master, this is not possible for the Cirrus CI config itself.

Fix that by cloning the pull request merged with the target branch before parsing the config.

This behaviour is also observed on other major CI providers, such as Travis CI.

Fixes cirruslabs/cirrus-ci-docs#662