### PR TITLE
Separate flag for cleaning working directory

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -39,6 +39,7 @@ func main() {
 	stopHook := flag.Bool("stop-hook", false, "pre stop flag")
 	commandFromPtr := flag.String("command-from", "", "Command to star execution from (inclusive)")
 	commandToPtr := flag.String("command-to", "", "Command to stop execution at (exclusive)")
+	cleanWorkingDir := flag.Bool("clean-working-dir", false, "clean working directory before exit")
 	flag.Parse()
 
 	if *help {
@@ -141,7 +142,7 @@ func main() {
 
 	go runHeartbeat(*taskIdPtr, *clientTokenPtr, conn)
 
-	buildExecutor := executor.NewExecutor(*taskIdPtr, *clientTokenPtr, *serverTokenPtr, *commandFromPtr, *commandToPtr)
+	buildExecutor := executor.NewExecutor(*taskIdPtr, *clientTokenPtr, *serverTokenPtr, *commandFromPtr, *commandToPtr, *cleanWorkingDir)
 	buildExecutor.RunBuild()
 
 	logFile.Close()

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -42,9 +42,10 @@ type Executor struct {
 	sensitiveValues    []string
 	commandFrom        string
 	commandTo          string
+	cleanWorkingDir    bool
 }
 
-func NewExecutor(taskId int64, clientToken, serverToken string, commandFrom string, commandTo string) *Executor {
+func NewExecutor(taskId int64, clientToken, serverToken string, commandFrom string, commandTo string, cleanWorkingDir bool) *Executor {
 	taskIdentification := &api.TaskIdentification{
 		TaskId: taskId,
 		Secret: clientToken,
@@ -57,6 +58,7 @@ func NewExecutor(taskId int64, clientToken, serverToken string, commandFrom stri
 		sensitiveValues:    make([]string, 0),
 		commandFrom:        commandFrom,
 		commandTo:          commandTo,
+		cleanWorkingDir:    cleanWorkingDir,
 	}
 }
 
@@ -139,7 +141,7 @@ func (executor *Executor) RunBuild() {
 		}
 		backgroundCommand.Logs.Finalize()
 	}
-	if executor.commandTo == "" {
+	if executor.cleanWorkingDir {
 		// this was a separate container or the last stage of a pipe
 		// we can clean up working directory now
 		err = os.RemoveAll(workingDir)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -142,8 +142,6 @@ func (executor *Executor) RunBuild() {
 		backgroundCommand.Logs.Finalize()
 	}
 	if executor.cleanWorkingDir {
-		// this was a separate container or the last stage of a pipe
-		// we can clean up working directory now
 		err = os.RemoveAll(workingDir)
 		if err != nil {
 			log.Printf("Failed to clean working directory: %v", err)


### PR DESCRIPTION
Since we don't need to clean it in CLI's dirty mode

Noticed it when tried to bump the agent version in CLI