### PR TITLE
.cirrus.yml: bump Release task resources

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -87,5 +87,7 @@ task:
     GITHUB_TOKEN: ENCRYPTED[!98ace8259c6024da912c14d5a3c5c6aac186890a8d4819fad78f3e0c41a4e0cd3a2537dd6e91493952fb056fa434be7c!]
   container:
     image: golang:latest
+    cpu: 4
+    memory: 12G
   install_script: curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
   release_script: ./bin/goreleaser


### PR DESCRIPTION
To fix the [failing build](https://cirrus-ci.com/task/5729677265338368) on `master`.