### PR TITLE
Speed-up image build by using goreleaser's --single-target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /tmp/cirrus-ci-agent
 ADD . /tmp/cirrus-ci-agent/
 
 RUN curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
-RUN ./bin/goreleaser build --snapshot
+RUN ./bin/goreleaser build --single-target --snapshot
 
 FROM alpine:latest
 


### PR DESCRIPTION
This flag was introduced recently in https://github.com/goreleaser/goreleaser/pull/2179.