### PR TITLE
Ability to share environment variables between task's scripts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/golang/protobuf v1.4.3
+	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2 h1:FlFbCRLd5Jr4iYXZufAvgWN6Ao0JrI5chLINnUXDDr0=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=

--- a/internal/cirrusenv/cirrusenv.go
+++ b/internal/cirrusenv/cirrusenv.go
@@ -1,0 +1,71 @@
+package cirrusenv
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/google/uuid"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type CirrusEnv struct {
+	file *os.File
+}
+
+func New() (*CirrusEnv, error) {
+	cirrusEnvFile, err := os.Create(filepath.Join(os.TempDir(), "cirrus-env-"+uuid.New().String()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &CirrusEnv{
+		file: cirrusEnvFile,
+	}, nil
+}
+
+func (ce *CirrusEnv) Path() string {
+	return ce.file.Name()
+}
+
+func (ce *CirrusEnv) Consume() (map[string]string, error) {
+	result := map[string]string{}
+
+	if _, err := ce.file.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(ce.file)
+
+	for scanner.Scan() {
+		splits := strings.SplitN(scanner.Text(), "=", 2)
+		if len(splits) != 2 {
+			return nil, fmt.Errorf("CIRRUS_ENV file should contain lines in KEY=VALUE format")
+		}
+
+		result[splits[0]] = splits[1]
+	}
+
+	return result, nil
+}
+
+func (ce *CirrusEnv) Close() error {
+	if err := ce.file.Close(); err != nil {
+		return err
+	}
+
+	return os.Remove(ce.Path())
+}
+
+func Merge(sources ...map[string]string) map[string]string {
+	destination := make(map[string]string)
+
+	for _, source := range sources {
+		for key, value := range source {
+			destination[key] = value
+		}
+	}
+
+	return destination
+}

--- a/internal/cirrusenv/cirrusenv.go
+++ b/internal/cirrusenv/cirrusenv.go
@@ -14,8 +14,10 @@ type CirrusEnv struct {
 	file *os.File
 }
 
-func New() (*CirrusEnv, error) {
-	cirrusEnvFile, err := os.Create(filepath.Join(os.TempDir(), "cirrus-env-"+uuid.New().String()))
+func New(taskID int64) (*CirrusEnv, error) {
+	filename := fmt.Sprintf("cirrus-env-task-%d-%s", taskID, uuid.New().String())
+
+	cirrusEnvFile, err := os.Create(filepath.Join(os.TempDir(), filename))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cirrusenv/cirrusenv_test.go
+++ b/internal/cirrusenv/cirrusenv_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCirrusEnv(t *testing.T) {
-	ce, err := cirrusenv.New()
+	ce, err := cirrusenv.New(42)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cirrusenv/cirrusenv_test.go
+++ b/internal/cirrusenv/cirrusenv_test.go
@@ -1,0 +1,31 @@
+package cirrusenv_test
+
+import (
+	"github.com/cirruslabs/cirrus-ci-agent/internal/cirrusenv"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"testing"
+)
+
+func TestCirrusEnv(t *testing.T) {
+	ce, err := cirrusenv.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ce.Close()
+
+	if err := ioutil.WriteFile(ce.Path(), []byte("A=B\nA==B"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	env, err := ce.Consume()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]string{
+		"A": "=B",
+	}
+
+	assert.Equal(t, expected, env)
+}

--- a/internal/executor/artifacts.go
+++ b/internal/executor/artifacts.go
@@ -17,18 +17,14 @@ import (
 	"path/filepath"
 )
 
-func (executor *Executor) UploadArtifacts(ctx context.Context, name string, artifactsInstruction *api.ArtifactsInstruction, customEnv map[string]string) bool {
-	logUploader, err := NewLogUploader(ctx, executor, name, customEnv)
-	if err != nil {
-		request := api.ReportAgentProblemRequest{
-			TaskIdentification: executor.taskIdentification,
-			Message:            fmt.Sprintf("Failed to initialize command clone log upload: %v", err),
-		}
-		client.CirrusClient.ReportAgentWarning(ctx, &request)
-		return false
-	}
-	defer logUploader.Finalize()
-
+func (executor *Executor) UploadArtifacts(
+	ctx context.Context,
+	logUploader *LogUploader,
+	name string,
+	artifactsInstruction *api.ArtifactsInstruction,
+	customEnv map[string]string,
+) bool {
+	var err error
 	var allAnnotations []model.Annotation
 
 	err = retry.Do(

--- a/internal/executor/cache.go
+++ b/internal/executor/cache.go
@@ -37,12 +37,14 @@ var httpClient = &http.Client{
 	Timeout: time.Minute * 5,
 }
 
-func (executor *Executor) DownloadCache(ctx context.Context, commandName string, cacheHost string, instruction *api.CacheInstruction, custom_env map[string]string) bool {
-	logUploader, err := NewLogUploader(ctx, executor, commandName, custom_env)
-	if err != nil {
-		return false
-	}
-	defer logUploader.Finalize()
+func (executor *Executor) DownloadCache(
+	ctx context.Context,
+	logUploader *LogUploader,
+	commandName string,
+	cacheHost string,
+	instruction *api.CacheInstruction,
+	custom_env map[string]string,
+) bool {
 	cacheKeyHash := sha256.New()
 
 	if len(instruction.FingerprintScripts) > 0 {
@@ -63,7 +65,7 @@ func (executor *Executor) DownloadCache(ctx context.Context, commandName string,
 
 	folderToCache := ExpandText(instruction.Folder, custom_env)
 
-	folderToCache, err = filepath.Abs(folderToCache)
+	folderToCache, err := filepath.Abs(folderToCache)
 	if err != nil {
 		message := fmt.Sprintf("\nFailed to compute absolute path for cache folder '%s': %s\n",
 			folderToCache, err)
@@ -288,12 +290,15 @@ func FetchCache(
 	return cacheFile, downloadDuration, nil
 }
 
-func (executor *Executor) UploadCache(ctx context.Context, commandName string, cacheHost string, instruction *api.UploadCacheInstruction, env map[string]string) bool {
-	logUploader, err := NewLogUploader(ctx, executor, commandName, env)
-	if err != nil {
-		return false
-	}
-	defer logUploader.Finalize()
+func (executor *Executor) UploadCache(
+	ctx context.Context,
+	logUploader *LogUploader,
+	commandName string,
+	cacheHost string,
+	instruction *api.UploadCacheInstruction,
+	env map[string]string,
+) bool {
+	var err error
 
 	cache := FindCache(instruction.CacheName)
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -298,7 +298,7 @@ func (executor *Executor) performStep(ctx context.Context, currentStep *api.Comm
 		defer logUploader.Finalize()
 	}
 
-	cirrusEnv, err := cirrusenv.New()
+	cirrusEnv, err := cirrusenv.New(executor.taskIdentification.TaskId)
 	if err != nil {
 		message := fmt.Sprintf("Failed initialize CIRRUS_ENV subsystem: %v", err)
 		log.Print(message)

--- a/internal/executor/logs.go
+++ b/internal/executor/logs.go
@@ -37,7 +37,7 @@ type LogUploader struct {
 	mutex sync.RWMutex
 }
 
-func NewLogUploader(ctx context.Context, executor *Executor, commandName string, env map[string]string) (*LogUploader, error) {
+func NewLogUploader(ctx context.Context, executor *Executor, commandName string) (*LogUploader, error) {
 	logClient, err := InitializeLogStreamClient(ctx, executor.taskIdentification, commandName, false)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func NewLogUploader(ctx context.Context, executor *Executor, commandName string,
 		valuesToMask:       executor.sensitiveValues,
 		closed:             false,
 
-		LogTimestamps: env["CIRRUS_LOG_TIMESTAMP"] == "true",
+		LogTimestamps: executor.env["CIRRUS_LOG_TIMESTAMP"] == "true",
 		GetTimestamp:  time.Now,
 		OweTimestamp:  true,
 	}


### PR DESCRIPTION
I have a little concern in regards to how critically we should treat the errors we get from `cirrusenv` in `performStep`:

* on one side, silently not setting environment variables that the user might expect to be set might result in some nasty security bugs (e.g. leaving the password or token empty)
* on the other side, failing the whole execution due to unability to create `CIRRUS_ENV` file on some platform + agent combinations (especially Windows + Persistent Worker) might be too much

But personally I'd vouch for the fail fast scenario, assuming we have a capacity to delicately roll the changes and see if they work on different configurations.

Resolves #139.