### PR TITLE
Fixed Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,11 +12,10 @@ steps:
     args: ['buildx', 'inspect', '--bootstrap']
     id: 'show-target-build-platforms'
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64', '-t', 'gcr.io/cirrus-ci-community/cirrus-ci-agent:$TAG_NAME', '-t', 'gcr.io/cirrus-ci-community/cirrus-ci-agent:latest', '.']
+    args: ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64', '-t', 'gcr.io/cirrus-ci-community/cirrus-ci-agent:$TAG_NAME', '-t', 'gcr.io/cirrus-ci-community/cirrus-ci-agent:latest', '--push', '.']
     id: 'build-multi-architecture-container-image'
 options:
   env:
     # to use buildx for multiarch build via buildx
     - 'DOCKER_CLI_EXPERIMENTAL=enabled'
-timeout: 3600s
-images: ['gcr.io/cirrus-ci-community/cirrus-ci-agent:$TAG_NAME', 'gcr.io/cirrus-ci-community/cirrus-ci-agent:latest']
+timeout: 1800s


### PR DESCRIPTION
Seem for a multi-arch build Cloud Build doesn't recognize `images` field. Instead let's do build and push right away as I found in this tutorial https://github.com/GoogleCloudPlatform/solutions-build-multi-architecture-images-tutorial/blob/593f898ff584ed47c0edc8b15f9f139c8b157b0c/terraform/cloud-build/build-docker-image-trigger.yaml#L28

Also lowered the timeout as `buildx` via QEMU is not that slow.