### PR TITLE
TerminalWrapper: emit an exit operation when we don't need to idle anymore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,31 +3,23 @@ module github.com/cirruslabs/cirrus-ci-agent
 go 1.15
 
 require (
-	github.com/Microsoft/go-winio v0.5.0 // indirect
-	github.com/ProtonMail/go-crypto v0.0.0-20210512092938-c05353c2d58c // indirect
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
 	github.com/cirruslabs/cirrus-ci-annotations v0.3.0
-	github.com/cirruslabs/terminal v0.2.5
+	github.com/cirruslabs/terminal v0.3.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.2.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
-	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d // indirect
-	github.com/kevinburke/ssh_config v1.1.0 // indirect
-	github.com/klauspost/compress v1.13.0 // indirect
 	github.com/klauspost/pgzip v1.2.5
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/pkg/errors v0.9.1
-	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210608053332-aa57babbf139
-	google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d // indirect
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -44,10 +44,12 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d h1:S2NE3iHSwP0XV47EEXL8mWmRdEfGscSJ+7EgePNgt0s=
 github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/cirruslabs/cirrus-ci-agent v1.51.0/go.mod h1:lEH1v2tn22T359W3fGjiAcYAY6jsqz75eHc4teh2nCY=
 github.com/cirruslabs/cirrus-ci-annotations v0.3.0 h1:VDFzTvXZ5yi4KPTct4xNbAurnSpKJnzIXgbKoDWAZww=
 github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
-github.com/cirruslabs/terminal v0.2.5 h1:7EtrZgvO7L+OniC9prx0c3YJdvn3KjZ0cXAgmpQk1Eo=
 github.com/cirruslabs/terminal v0.2.5/go.mod h1:ubLe9fvd4FYeQV08ob5TNp9tsAfE0efkFtPrlKAwIKw=
+github.com/cirruslabs/terminal v0.3.0 h1:JppGMpaWOGiCKdiWVo9/admbZM/uoX+xw7GSxYGjtiw=
+github.com/cirruslabs/terminal v0.3.0/go.mod h1:fsHF06OJGo7W7pntw5rQXPsmdv34gzxbsOLWFBFyQHM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/internal/executor/terminalwrapper/terminalwrapper.go
+++ b/internal/executor/terminalwrapper/terminalwrapper.go
@@ -78,7 +78,7 @@ func New(ctx context.Context, taskIdentification *api.TaskIdentification, server
 				wrapper.operationChan <- &LogOperation{Message: fmt.Sprintf("Terminal host failed: %v", err)}
 			}),
 			retry.Context(ctx),
-			retry.Delay(1*time.Second), retry.MaxDelay(1*time.Second),
+			retry.Delay(5*time.Second), retry.MaxDelay(5*time.Second),
 			retry.Attempts(math.MaxUint32), retry.LastErrorOnly(true),
 		)
 	}()

--- a/internal/executor/terminalwrapper/terminalwrapper.go
+++ b/internal/executor/terminalwrapper/terminalwrapper.go
@@ -97,7 +97,9 @@ func (wrapper *Wrapper) Wait() chan Operation {
 			durationSinceLastActivity := time.Since(wrapper.terminalHost.LastActivity())
 
 			if durationSinceLastActivity >= minIdleDuration {
-				break
+				wrapper.operationChan <- &ExitOperation{Success: true}
+
+				return
 			}
 
 			// Here the durationSinceLastActivity is less than minIdleDuration (see the check above),

--- a/internal/executor/terminalwrapper/terminalwrapper.go
+++ b/internal/executor/terminalwrapper/terminalwrapper.go
@@ -8,7 +8,6 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/client"
-	"github.com/cirruslabs/cirrus-ci-agent/pkg/grpchelper"
 	"github.com/cirruslabs/terminal/pkg/host"
 	"github.com/cirruslabs/terminal/pkg/host/session"
 	"math"
@@ -51,13 +50,7 @@ func New(ctx context.Context, taskIdentification *api.TaskIdentification, server
 	}
 
 	if serverAddress != "" {
-		parsedAddress, insecure := grpchelper.TransportSettings(serverAddress)
-
-		terminalHostOpts = append(terminalHostOpts, host.WithServerAddress(parsedAddress))
-
-		if insecure {
-			terminalHostOpts = append(terminalHostOpts, host.WithServerInsecure())
-		}
+		terminalHostOpts = append(terminalHostOpts, host.WithServerAddress(serverAddress))
 	}
 
 	wrapper.terminalHost, err = host.New(terminalHostOpts...)


### PR DESCRIPTION
Also support specifying the `TerminalHost`'s server address using the agent's `grpchelper` syntax.