### PR TITLE
Set Content-Length for cache uploads

### DIFF
--- a/internal/executor/cache.go
+++ b/internal/executor/cache.go
@@ -463,6 +463,11 @@ func UploadCacheFile(ctx context.Context, cacheHost string, cacheKey string, cac
 	if err != nil {
 		return err
 	}
+	fileStat, err := cacheFile.Stat()
+	if err != nil {
+		return err
+	}
+	req.ContentLength = fileStat.Size()
 	req.Header.Set("Content-Type", "application/octet-stream")
 	response, err := httpClient.Do(req)
 	if err != nil {

--- a/internal/http_cache/http_cache.go
+++ b/internal/http_cache/http_cache.go
@@ -176,9 +176,7 @@ func uploadCacheEntry(w http.ResponseWriter, r *http.Request, cacheKey string) {
 		return
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
-	if r.ContentLength >= 0 {
-		req.Header.Set("Content-Length", strconv.FormatInt(r.ContentLength, 10))
-	}
+	req.ContentLength = r.ContentLength
 	for k, v := range generateResp.GetExtraHeaders() {
 		req.Header.Set(k, v)
 	}


### PR DESCRIPTION
Otherwise the Content-Type is set to 'chunked' and S3 presigned URLs do not support "chunked" uploads.

Here is context https://github.com/aws/aws-sdk-go/issues/1414#issuecomment-317573071