### PR TITLE
TerminalWrapper: increase idle time and take into account the last registration time when waiting on activity

### DIFF
--- a/internal/executor/terminalwrapper/terminalwrapper.go
+++ b/internal/executor/terminalwrapper/terminalwrapper.go
@@ -98,7 +98,16 @@ func (wrapper *Wrapper) Wait() chan Operation {
 		wrapper.operationChan <- &LogOperation{Message: message}
 
 		for {
-			durationSinceLastActivity := time.Since(wrapper.terminalHost.LastActivity())
+			lastActivity := wrapper.terminalHost.LastActivity()
+
+			// Take into account the last registration time too,
+			// since for us this is also a substantial activity
+			lastRegistration := wrapper.terminalHost.LastRegistration()
+			if lastRegistration.After(lastActivity) {
+				lastActivity = lastRegistration
+			}
+
+			durationSinceLastActivity := time.Since(lastActivity)
 
 			if durationSinceLastActivity >= minIdleDuration {
 				wrapper.operationChan <- &ExitOperation{Success: true}

--- a/internal/executor/terminalwrapper/terminalwrapper.go
+++ b/internal/executor/terminalwrapper/terminalwrapper.go
@@ -81,7 +81,7 @@ func New(ctx context.Context, taskIdentification *api.TaskIdentification, server
 
 func (wrapper *Wrapper) Wait() chan Operation {
 	go func() {
-		const minIdleDuration = 1 * time.Minute
+		const minIdleDuration = 10 * time.Minute
 
 		if wrapper.terminalHost == nil {
 			wrapper.operationChan <- &ExitOperation{Success: false}


### PR DESCRIPTION
https://github.com/cirruslabs/cirrus-ci-agent/commit/7955a101ba780dff775f77a6d8876953d31c9ffa is an obvious one, while the https://github.com/cirruslabs/cirrus-ci-agent/commit/6d9802031bbfcaefa09fd6aa597f04b5e32c7508 makes sure we don't terminate the session too early after receiving the initial connection, which improves UX in the web UI since it's too easy to miss the terminal presence otherwise.