### PR TITLE
Simplification for command updates

### DIFF
--- a/internal/executor/commanditerator/commanditerator.go
+++ b/internal/executor/commanditerator/commanditerator.go
@@ -16,28 +16,14 @@ func New(commands []*api.Command) *CommandIterator {
 	}
 }
 
-func (ci *CommandIterator) getOrPeek(
-	failedAtLeastOnce bool,
-	peek bool,
-	includeSkipped bool,
-) (command *api.Command, skipped bool) {
-	shadowIdx := ci.idx
-	defer func() {
-		if peek {
-			return
-		}
-
-		ci.idx = shadowIdx
-	}()
-
+func (ci *CommandIterator) getOrPeek(failedAtLeastOnce bool, includeSkipped bool) (command *api.Command, skipped bool) {
 	for {
-		if shadowIdx >= len(ci.commands) {
+		if ci.idx >= len(ci.commands) {
 			return nil, false
 		}
 
-		nextCommand := ci.commands[shadowIdx]
-
-		shadowIdx++
+		nextCommand := ci.commands[ci.idx]
+		ci.idx++
 
 		if shouldRun(nextCommand, failedAtLeastOnce) {
 			return nextCommand, false
@@ -48,21 +34,12 @@ func (ci *CommandIterator) getOrPeek(
 }
 
 func (ci *CommandIterator) GetNext(failedAtLeastOnce bool) *api.Command {
-	command, _ := ci.getOrPeek(failedAtLeastOnce, false, false)
+	command, _ := ci.getOrPeek(failedAtLeastOnce, false)
 	return command
 }
 
 func (ci *CommandIterator) GetNextWithSkipped(failedAtLeastOnce bool) (*api.Command, bool) {
-	return ci.getOrPeek(failedAtLeastOnce, false, true)
-}
-
-func (ci *CommandIterator) PeekNext(failedAtLeastOnce bool) *api.Command {
-	command, _ := ci.getOrPeek(failedAtLeastOnce, true, false)
-	return command
-}
-
-func (ci *CommandIterator) PeekNextWithSkipped(failedAtLeastOnce bool) (*api.Command, bool) {
-	return ci.getOrPeek(failedAtLeastOnce, true, true)
+	return ci.getOrPeek(failedAtLeastOnce, true)
 }
 
 func shouldRun(command *api.Command, failedAtLeastOnce bool) bool {

--- a/internal/executor/commanditerator/commanditerator_test.go
+++ b/internal/executor/commanditerator/commanditerator_test.go
@@ -10,7 +10,6 @@ import (
 func TestEmptyCommandList(t *testing.T) {
 	ci := commanditerator.New([]*api.Command{})
 
-	assert.Nil(t, ci.PeekNext(false))
 	assert.Nil(t, ci.GetNext(false))
 }
 
@@ -21,25 +20,10 @@ func TestPeek(t *testing.T) {
 		{Name: "third"},
 	})
 
-	assert.Equal(t, "first", ci.PeekNext(false).Name)
 	assert.Equal(t, "first", ci.GetNext(false).Name)
-	assert.Equal(t, "second", ci.PeekNext(false).Name)
 	assert.Equal(t, "second", ci.GetNext(false).Name)
-	assert.Equal(t, "third", ci.PeekNext(false).Name)
 	assert.Equal(t, "third", ci.GetNext(false).Name)
-	assert.Nil(t, ci.PeekNext(false))
 	assert.Nil(t, ci.GetNext(false))
-}
-
-func TestPeekIsPure(t *testing.T) {
-	ci := commanditerator.New([]*api.Command{
-		{Name: "first"},
-		{Name: "second"},
-		{Name: "third"},
-	})
-
-	assert.Equal(t, "first", ci.PeekNext(false).Name)
-	assert.Equal(t, "first", ci.PeekNext(false).Name)
 }
 
 func TestExecutionBehaviorIsRespected(t *testing.T) {
@@ -49,14 +33,10 @@ func TestExecutionBehaviorIsRespected(t *testing.T) {
 	}
 
 	ci := commanditerator.New(commands)
-	next, skipped := ci.PeekNextWithSkipped(true)
-	assert.Equal(t, "should be skipped", next.Name)
-	assert.True(t, skipped)
-	next, skipped = ci.GetNextWithSkipped(true)
+	next, skipped := ci.GetNextWithSkipped(true)
 	assert.Equal(t, "should be skipped", next.Name)
 	assert.True(t, skipped)
 
 	ci = commanditerator.New(commands)
-	assert.Equal(t, "should be returned", ci.PeekNext(true).Name)
 	assert.Equal(t, "should be returned", ci.GetNext(true).Name)
 }


### PR DESCRIPTION
Maybe simplify the logic in #168 like this?

I removed `Peek` methods since they were only used in tests and simplified the for loop for sending updates