### PR TITLE
Increase retry timeout

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -240,7 +240,7 @@ func dialWithTimeout(ctx context.Context, apiEndpoint string) (*grpc.ClientConn,
 			grpc_retry.UnaryClientInterceptor(
 				grpc_retry.WithMax(3),
 				grpc_retry.WithCodes(retryCodes...),
-				grpc_retry.WithPerRetryTimeout(10*time.Second),
+				grpc_retry.WithPerRetryTimeout(60*time.Second),
 			),
 		),
 	)


### PR DESCRIPTION
10 seconds seems a bit too low in cases when there is a general slowness and a retry is needed