### PR TITLE
cgroup-aware metrics collection

### DIFF
--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"context"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	logger := logrus.New()
+
+	_, errChan := metrics.Run(context.Background(), logger)
+
+	if err := <-errChan; err != nil {
+		logrus.Fatalf("metrics failed: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,9 @@ require (
 	github.com/klauspost/pgzip v1.2.5
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/procfs v0.7.3
 	github.com/shirou/gopsutil v3.21.7+incompatible
+	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tklauser/go-sysconf v0.3.7 // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -270,6 +271,8 @@ github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7q
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
+github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -395,6 +398,7 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -92,7 +92,7 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 	// Start collecting metrics
 	metricsCtx, metricsCancel := context.WithCancel(ctx)
 	defer metricsCancel()
-	metricsResultChan, metricsErrChan := metrics.Run(metricsCtx)
+	metricsResultChan, metricsErrChan := metrics.Run(metricsCtx, nil)
 
 	log.Println("Getting initial commands...")
 

--- a/internal/executor/metrics/metrics.go
+++ b/internal/executor/metrics/metrics.go
@@ -37,11 +37,13 @@ func Run(ctx context.Context, logger logrus.FieldLogger) (chan *api.ResourceUtil
 	if err == nil {
 		cpuSrc, err := cpu.NewCPU(resolver)
 		if err == nil {
+			logger.Infof("CPU metrics are now cgroup-aware")
 			cpuSource = cpuSrc
 		}
 
 		memorySrc, err := memory.NewMemory(resolver)
 		if err == nil {
+			logger.Infof("memory metrics are now cgroup-aware")
 			memorySource = memorySrc
 		}
 	}

--- a/internal/executor/metrics/metrics.go
+++ b/internal/executor/metrics/metrics.go
@@ -14,6 +14,8 @@ import (
 	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/system"
 	"github.com/dustin/go-humanize"
 	"github.com/sirupsen/logrus"
+	"log"
+	"runtime"
 	"time"
 )
 
@@ -34,7 +36,12 @@ func Run(ctx context.Context, logger logrus.FieldLogger) (chan *api.ResourceUtil
 	memorySource = systemSource
 
 	resolver, err := resolver.New()
-	if err == nil {
+	if err != nil {
+		if runtime.GOOS == "linux" {
+			log.Printf("cgroup resolver initialization failed (%v), falling back to system-wide metrics collection",
+				err)
+		}
+	} else {
 		cpuSrc, err := cpu.NewCPU(resolver)
 		if err == nil {
 			logger.Infof("CPU metrics are now cgroup-aware")

--- a/internal/executor/metrics/metrics.go
+++ b/internal/executor/metrics/metrics.go
@@ -44,13 +44,17 @@ func Run(ctx context.Context, logger logrus.FieldLogger) (chan *api.ResourceUtil
 	} else {
 		cpuSrc, err := cpu.NewCPU(resolver)
 		if err == nil {
-			logger.Infof("CPU metrics are now cgroup-aware")
+			if logger != nil {
+				logger.Infof("CPU metrics are now cgroup-aware")
+			}
 			cpuSource = cpuSrc
 		}
 
 		memorySrc, err := memory.NewMemory(resolver)
 		if err == nil {
-			logger.Infof("memory metrics are now cgroup-aware")
+			if logger != nil {
+				logger.Infof("memory metrics are now cgroup-aware")
+			}
 			memorySource = memorySrc
 		}
 	}

--- a/internal/executor/metrics/metrics.go
+++ b/internal/executor/metrics/metrics.go
@@ -1,4 +1,4 @@
-// +build !windows !arm
+// +build !windows !arm,!arm64
 
 package metrics
 

--- a/internal/executor/metrics/metrics_test.go
+++ b/internal/executor/metrics/metrics_test.go
@@ -12,7 +12,7 @@ func TestMetrics(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	resultChan, errChan := metrics.Run(ctx)
+	resultChan, errChan := metrics.Run(ctx, nil)
 
 	select {
 	case result := <-resultChan:

--- a/internal/executor/metrics/metrics_unsupported.go
+++ b/internal/executor/metrics/metrics_unsupported.go
@@ -1,4 +1,4 @@
-// +build windows,arm
+// +build windows,arm windows,arm64
 
 package metrics
 

--- a/internal/executor/metrics/metrics_unsupported.go
+++ b/internal/executor/metrics/metrics_unsupported.go
@@ -5,9 +5,10 @@ package metrics
 import (
 	"context"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/sirupsen/logrus"
 )
 
-func Run(ctx context.Context) (chan *api.ResourceUtilization, chan error) {
+func Run(ctx context.Context, logger logrus.FieldLogger) (chan *api.ResourceUtilization, chan error) {
 	resultChan := make(chan *api.ResourceUtilization, 1)
 	errChan := make(chan error, 1)
 

--- a/internal/executor/metrics/source/cgroup/cgroup.go
+++ b/internal/executor/metrics/source/cgroup/cgroup.go
@@ -1,0 +1,8 @@
+package cgroup
+
+import "errors"
+
+var (
+	ErrUnconfigured        = errors.New("cgroup is not configured for this process")
+	ErrUnsupportedPlatform = errors.New("cgroup is not supported on this platform")
+)

--- a/internal/executor/metrics/source/cgroup/cpu/cpu.go
+++ b/internal/executor/metrics/source/cgroup/cpu/cpu.go
@@ -1,0 +1,5 @@
+package cpu
+
+type CPUWithUsage interface {
+	CPUUsage() (float64, error)
+}

--- a/internal/executor/metrics/source/cgroup/cpu/cpu_linux.go
+++ b/internal/executor/metrics/source/cgroup/cpu/cpu_linux.go
@@ -1,0 +1,105 @@
+package cpu
+
+import (
+	"context"
+	"fmt"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/resolver"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/subsystem"
+	gopsutilcpu "github.com/shirou/gopsutil/cpu"
+	"math"
+	"time"
+)
+
+type VersionlessCPU struct {
+	versionedCPU CPUWithUsage
+}
+
+func NewCPU(resolver resolver.Resolver) (source.CPU, error) {
+	versionlessCPU := &VersionlessCPU{}
+
+	const desiredSubsystem = subsystem.Cpuacct
+
+	v1path, v2path, err := resolver.Resolve(desiredSubsystem)
+	if err != nil {
+		return nil, err
+	}
+
+	if v1path != "" {
+		versionlessCPU.versionedCPU, err = NewV1(v1path)
+	} else if v2path != "" {
+		versionlessCPU.versionedCPU, err = NewV2(v2path)
+	} else {
+		err = fmt.Errorf("%w for subsystem %s", cgroup.ErrUnconfigured, desiredSubsystem)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return versionlessCPU, nil
+}
+
+func (cpu *VersionlessCPU) NumCpusUsed(ctx context.Context, pollInterval time.Duration) (float64, error) {
+	// Before
+	times, err := gopsutilcpu.Times(true)
+	if err != nil {
+		return 0, err
+	}
+	var systemBefore float64
+	for _, time := range times {
+		systemBefore += time.Total()
+	}
+
+	cgroupBefore, err := cpu.versionedCPU.CPUUsage()
+	if err != nil {
+		return 0, err
+	}
+
+	// Sleep
+	if err := contextAwareSleep(ctx, pollInterval); err != nil {
+		return 0, err
+	}
+
+	// After
+	times, err = gopsutilcpu.Times(true)
+	if err != nil {
+		return 0, err
+	}
+	var systemAfter float64
+	for _, time := range times {
+		systemAfter += time.Total()
+	}
+
+	cgroupAfter, err := cpu.versionedCPU.CPUUsage()
+	if err != nil {
+		return 0, err
+	}
+
+	// Calculate number of CPUs used
+	cgroupDelta := cgroupAfter - cgroupBefore
+	if cgroupDelta < 0 {
+		cgroupDelta = 0
+	}
+
+	systemDelta := systemAfter - systemBefore
+	if systemDelta < 0 {
+		systemDelta = 100
+	}
+
+	numCpus := len(times)
+
+	return math.Min(100, math.Max(0, cgroupDelta/systemDelta)) * float64(numCpus), nil
+}
+
+func contextAwareSleep(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/executor/metrics/source/cgroup/cpu/cpu_unsupported.go
+++ b/internal/executor/metrics/source/cgroup/cpu/cpu_unsupported.go
@@ -1,0 +1,13 @@
+// +build !linux
+
+package cpu
+
+import (
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/resolver"
+)
+
+func NewCPU(resolver resolver.Resolver) (source.CPU, error) {
+	return nil, cgroup.ErrUnsupportedPlatform
+}

--- a/internal/executor/metrics/source/cgroup/cpu/v1.go
+++ b/internal/executor/metrics/source/cgroup/cpu/v1.go
@@ -1,0 +1,37 @@
+// +build linux
+
+package cpu
+
+import (
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/parser"
+	"os"
+	"path/filepath"
+)
+
+type V1CPU struct {
+	path string
+}
+
+func NewV1(path string) (*V1CPU, error) {
+	return &V1CPU{
+		path: path,
+	}, nil
+}
+
+func (cpu *V1CPU) CPUUsage() (float64, error) {
+	file, err := os.Open(filepath.Join(cpu.path, "cpuacct.usage"))
+	if err != nil {
+		return 0, err
+	}
+
+	result, err := parser.ParseSingleValueFile(file)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := file.Close(); err != nil {
+		return 0, err
+	}
+
+	return float64(result) / 1_000_000_000, nil
+}

--- a/internal/executor/metrics/source/cgroup/cpu/v2.go
+++ b/internal/executor/metrics/source/cgroup/cpu/v2.go
@@ -1,0 +1,44 @@
+// +build linux
+
+package cpu
+
+import (
+	"fmt"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/parser"
+	"os"
+	"path/filepath"
+)
+
+type V2CPU struct {
+	path string
+}
+
+func NewV2(path string) (*V2CPU, error) {
+	return &V2CPU{
+		path: path,
+	}, nil
+}
+
+func (cpu *V2CPU) CPUUsage() (float64, error) {
+	file, err := os.Open(filepath.Join(cpu.path, "cpu.stat"))
+	if err != nil {
+		return 0, err
+	}
+
+	kvs, err := parser.ParseKeyValueFile(file)
+	if err != nil {
+		return 0, err
+	}
+
+	const usageUsecFieldName = "usage_usec"
+	usageUsec, ok := kvs[usageUsecFieldName]
+	if !ok {
+		return 0, fmt.Errorf("%w: missing %s field", parser.ErrInvalidFormat, usageUsecFieldName)
+	}
+
+	if err := file.Close(); err != nil {
+		return 0, err
+	}
+
+	return float64(usageUsec) / 1_000_000, nil
+}

--- a/internal/executor/metrics/source/cgroup/memory/memory.go
+++ b/internal/executor/metrics/source/cgroup/memory/memory.go
@@ -1,0 +1,5 @@
+package memory
+
+type MemoryWithUsage interface {
+	MemoryUsage() (float64, error)
+}

--- a/internal/executor/metrics/source/cgroup/memory/memory_linux.go
+++ b/internal/executor/metrics/source/cgroup/memory/memory_linux.go
@@ -1,0 +1,43 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/resolver"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/subsystem"
+)
+
+type VersionlessMemory struct {
+	versionedMemory MemoryWithUsage
+}
+
+func NewMemory(resolver resolver.Resolver) (source.Memory, error) {
+	versionlessMemory := &VersionlessMemory{}
+
+	const desiredSubsystem = subsystem.Memory
+
+	v1path, v2path, err := resolver.Resolve(desiredSubsystem)
+	if err != nil {
+		return nil, err
+	}
+
+	if v1path != "" {
+		versionlessMemory.versionedMemory, err = NewV1(v1path)
+	} else if v2path != "" {
+		versionlessMemory.versionedMemory, err = NewV2(v2path)
+	} else {
+		err = fmt.Errorf("%w for subsystem %s", cgroup.ErrUnconfigured, desiredSubsystem)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return versionlessMemory, nil
+}
+
+func (memory *VersionlessMemory) AmountMemoryUsed(ctx context.Context) (float64, error) {
+	return memory.versionedMemory.MemoryUsage()
+}

--- a/internal/executor/metrics/source/cgroup/memory/memory_unsupported.go
+++ b/internal/executor/metrics/source/cgroup/memory/memory_unsupported.go
@@ -1,0 +1,13 @@
+// +build !linux
+
+package memory
+
+import (
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/resolver"
+)
+
+func NewMemory(resolver resolver.Resolver) (source.Memory, error) {
+	return nil, cgroup.ErrUnsupportedPlatform
+}

--- a/internal/executor/metrics/source/cgroup/memory/v1.go
+++ b/internal/executor/metrics/source/cgroup/memory/v1.go
@@ -1,0 +1,58 @@
+// +build linux
+
+package memory
+
+import (
+	"fmt"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/parser"
+	"os"
+	"path/filepath"
+)
+
+type V1Memory struct {
+	path string
+}
+
+func NewV1(path string) (*V1Memory, error) {
+	return &V1Memory{
+		path: path,
+	}, nil
+}
+
+func (memory *V1Memory) MemoryUsage() (float64, error) {
+	file, err := os.Open(filepath.Join(memory.path, "memory.usage_in_bytes"))
+	if err != nil {
+		return 0, err
+	}
+
+	total, err := parser.ParseSingleValueFile(file)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := file.Close(); err != nil {
+		return 0, err
+	}
+
+	file, err = os.Open(filepath.Join(memory.path, "memory.stat"))
+	if err != nil {
+		return 0, err
+	}
+
+	kvs, err := parser.ParseKeyValueFile(file)
+	if err != nil {
+		return 0, err
+	}
+
+	const totalInactiveFileFieldName = "total_inactive_file"
+	totalInactiveFile, ok := kvs[totalInactiveFileFieldName]
+	if !ok {
+		return 0, fmt.Errorf("%w: missing %s field", parser.ErrInvalidFormat, totalInactiveFileFieldName)
+	}
+
+	if err := file.Close(); err != nil {
+		return 0, err
+	}
+
+	return float64(total - totalInactiveFile), nil
+}

--- a/internal/executor/metrics/source/cgroup/memory/v2.go
+++ b/internal/executor/metrics/source/cgroup/memory/v2.go
@@ -1,0 +1,58 @@
+// +build linux
+
+package memory
+
+import (
+	"fmt"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/parser"
+	"os"
+	"path/filepath"
+)
+
+type V2Memory struct {
+	path string
+}
+
+func NewV2(path string) (*V2Memory, error) {
+	return &V2Memory{
+		path: path,
+	}, nil
+}
+
+func (memory *V2Memory) MemoryUsage() (float64, error) {
+	file, err := os.Open(filepath.Join(memory.path, "memory.current"))
+	if err != nil {
+		return 0, err
+	}
+
+	total, err := parser.ParseSingleValueFile(file)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := file.Close(); err != nil {
+		return 0, err
+	}
+
+	file, err = os.Open(filepath.Join(memory.path, "memory.stat"))
+	if err != nil {
+		return 0, err
+	}
+
+	kvs, err := parser.ParseKeyValueFile(file)
+	if err != nil {
+		return 0, err
+	}
+
+	const inactiveFileFieldName = "inactive_file"
+	inactiveFile, ok := kvs[inactiveFileFieldName]
+	if !ok {
+		return 0, fmt.Errorf("%w: missing %s field", parser.ErrInvalidFormat, inactiveFileFieldName)
+	}
+
+	if err := file.Close(); err != nil {
+		return 0, err
+	}
+
+	return float64(total - inactiveFile), nil
+}

--- a/internal/executor/metrics/source/cgroup/parser/parser.go
+++ b/internal/executor/metrics/source/cgroup/parser/parser.go
@@ -1,0 +1,76 @@
+package parser
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+var (
+	ErrInvalidFormat = errors.New("invalid format")
+	ErrInternal      = errors.New("internal parser error")
+)
+
+func ParseSingleValueFile(input io.Reader) (uint64, error) {
+	scanner := bufio.NewScanner(input)
+
+	if !scanner.Scan() {
+		err := scanner.Err()
+		if err == nil {
+			err = io.EOF
+		}
+
+		return 0, fmt.Errorf("%w: got error while reading line: %v", ErrInvalidFormat, err)
+	}
+
+	line := scanner.Text()
+	parsed, err := strconv.ParseUint(line, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	if scanner.Scan() {
+		return 0, fmt.Errorf("%w: extraneous lines found", ErrInvalidFormat)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("%w: %v", ErrInternal, err)
+	}
+
+	return parsed, nil
+}
+
+func ParseKeyValueFile(input io.Reader) (map[string]uint64, error) {
+	result := map[string]uint64{}
+
+	scanner := bufio.NewScanner(input)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		splits := strings.Split(line, " ")
+		if len(splits) != 2 {
+			return nil, fmt.Errorf("%w: each line should be splittable into 2 parts, got %d parts",
+				ErrInvalidFormat, len(splits))
+		}
+
+		key := splits[0]
+		value := splits[1]
+
+		parsedValue, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("%w: failed to parse value %q: %v", ErrInvalidFormat, value, err)
+		}
+
+		result[key] = parsedValue
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInternal, err)
+	}
+
+	return result, nil
+}

--- a/internal/executor/metrics/source/cgroup/parser/parser_test.go
+++ b/internal/executor/metrics/source/cgroup/parser/parser_test.go
@@ -1,0 +1,65 @@
+package parser
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseSingleValueFile(t *testing.T) {
+	memoryUsageInBytesFile := `252387328
+`
+
+	result, err := ParseSingleValueFile(bytes.NewBufferString(memoryUsageInBytesFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.EqualValues(t, 252387328, result)
+}
+
+func TestParseKeyValueFile(t *testing.T) {
+	memoryStatFile := `cache 25182208
+rss 2654208
+rss_huge 0
+shmem 0
+mapped_file 9191424
+dirty 0
+writeback 0
+pgpgin 46629
+pgpgout 39828
+pgfault 32208
+pgmajfault 99
+inactive_anon 8192
+active_anon 2625536
+inactive_file 4861952
+active_file 20307968
+unevictable 0
+hierarchical_memory_limit 9223372036854771712
+total_cache 227909632
+total_rss 24612864
+total_rss_huge 0
+total_shmem 4055040
+total_mapped_file 30547968
+total_dirty 0
+total_writeback 0
+total_pgpgin 205821
+total_pgpgout 144020
+total_pgfault 257202
+total_pgmajfault 297
+total_inactive_anon 4108288
+total_active_anon 24592384
+total_inactive_file 165294080
+total_active_file 60411904
+total_unevictable 0
+`
+
+	result, err := ParseKeyValueFile(bytes.NewBufferString(memoryStatFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	totalInactiveFile, ok := result["total_inactive_file"]
+	assert.True(t, ok)
+	assert.EqualValues(t, totalInactiveFile, 165294080)
+}

--- a/internal/executor/metrics/source/cgroup/resolver/resolver.go
+++ b/internal/executor/metrics/source/cgroup/resolver/resolver.go
@@ -1,0 +1,7 @@
+package resolver
+
+import "github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/subsystem"
+
+type Resolver interface {
+	Resolve(subsystemName subsystem.SubsystemName) (string, string, error)
+}

--- a/internal/executor/metrics/source/cgroup/resolver/resolver_linux.go
+++ b/internal/executor/metrics/source/cgroup/resolver/resolver_linux.go
@@ -1,0 +1,137 @@
+package resolver
+
+import (
+	"errors"
+	"fmt"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/subsystem"
+	"github.com/prometheus/procfs"
+	"path/filepath"
+)
+
+type LinuxResolver struct {
+	mountInfos []*procfs.MountInfo
+	cgroups    []procfs.Cgroup
+}
+
+type Mount struct {
+	Root       string
+	MountPoint string
+}
+
+const (
+	v1FSType            = "cgroup"
+	v2FSType            = "cgroup2"
+	preferredMountpoint = "/sys/fs/cgroup"
+)
+
+var (
+	ErrInitFailed = errors.New("failed to initialize cgroup resolver")
+	ErrInternal   = errors.New("internal cgroup resolver error")
+)
+
+func New() (*LinuxResolver, error) {
+	self, err := procfs.Self()
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to open /proc/self: %v", ErrInitFailed, err)
+	}
+
+	mountInfos, err := self.MountInfo()
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to retrieve mounts: %v", ErrInitFailed, err)
+	}
+
+	cgroups, err := self.Cgroups()
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to retrieve cgroups: %v", ErrInitFailed, err)
+	}
+
+	return &LinuxResolver{
+		mountInfos: mountInfos,
+		cgroups:    cgroups,
+	}, nil
+}
+
+func (resolver *LinuxResolver) Resolve(subsystemName subsystem.SubsystemName) (string, string, error) {
+	// Determine where a cgroup hierarchy for a given subsystem is mounted (e.g. /sys/fs/cgroup/cpuset)
+	var v1mount *Mount
+	var v2mount *Mount
+
+	for _, mount := range resolver.mountInfos {
+		switch mount.FSType {
+		case v1FSType:
+			if _, ok := mount.SuperOptions[string(subsystemName)]; !ok {
+				continue
+			}
+
+			if v1mount != nil && v1mount.MountPoint == preferredMountpoint {
+				continue
+			}
+
+			v1mount = &Mount{Root: mount.Root, MountPoint: mount.MountPoint}
+		case v2FSType:
+			if v2mount != nil && v2mount.MountPoint == preferredMountpoint {
+				continue
+			}
+
+			v2mount = &Mount{Root: mount.Root, MountPoint: mount.MountPoint}
+		}
+	}
+
+	// Determine the path within a cgroup hierarchy where our process is placed
+	// (e.g. /docker/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855)
+	var pathWithinV1Hierarchy string
+	var pathWithinV2Hierarchy string
+
+	for _, cgroup := range resolver.cgroups {
+		// From /proc/[pid]/cgroup's documentation[1] on hierarchy ID field:
+		//
+		// >For the cgroups version 2 hierarchy, this field contains the value 0.
+		//
+		// From /proc/[pid]/cgroup's documentation[1] on controllers field:
+		//
+		// >For the cgroups version 2 hierarchy, this field is empty.
+		//
+		// [1]: https://man7.org/linux/man-pages/man7/cgroups.7.html
+		if cgroup.HierarchyID == 0 && len(cgroup.Controllers) == 0 {
+			pathWithinV2Hierarchy = cgroup.Path
+		}
+
+		for _, controller := range cgroup.Controllers {
+			if controller == string(subsystemName) {
+				pathWithinV1Hierarchy = cgroup.Path
+			}
+		}
+	}
+
+	var subsystemPathV1 string
+	var subsystemPathV2 string
+
+	// Determine the final path for a given subsystem, preferring cgroup version 1
+	if pathWithinV1Hierarchy != "" {
+		if v1mount == nil {
+			return "", "", fmt.Errorf("%w: process uses cgroup version 1, yet it's hierarchy is not mounted",
+				ErrInternal)
+		}
+
+		normalizedPath, err := filepath.Rel(v1mount.Root, pathWithinV1Hierarchy)
+		if err != nil {
+			return "", "", fmt.Errorf("%w: failed to normalize subsystem path: %v", ErrInternal, err)
+		}
+
+		subsystemPathV1 = filepath.Join(v1mount.MountPoint, normalizedPath)
+	} else if pathWithinV2Hierarchy != "" {
+		if v2mount == nil {
+			return "", "", fmt.Errorf("%w: process uses cgroup version 2, yet it's hierarchy is not mounted",
+				ErrInternal)
+		}
+
+		normalizedPath, err := filepath.Rel(v2mount.Root, pathWithinV2Hierarchy)
+		if err != nil {
+			return "", "", fmt.Errorf("%w: failed to normalize subsystem path: %v", ErrInternal, err)
+		}
+
+		subsystemPathV2 = filepath.Join(v2mount.MountPoint, normalizedPath)
+	}
+
+	return subsystemPathV1, subsystemPathV2, nil
+}

--- a/internal/executor/metrics/source/cgroup/resolver/resolver_unsupported.go
+++ b/internal/executor/metrics/source/cgroup/resolver/resolver_unsupported.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package resolver
+
+import (
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup"
+)
+
+func New() (Resolver, error) {
+	return nil, cgroup.ErrUnsupportedPlatform
+}

--- a/internal/executor/metrics/source/cgroup/subsystem/subsystem.go
+++ b/internal/executor/metrics/source/cgroup/subsystem/subsystem.go
@@ -1,0 +1,8 @@
+package subsystem
+
+type SubsystemName string
+
+const (
+	Cpuacct SubsystemName = "cpuacct"
+	Memory  SubsystemName = "memory"
+)

--- a/internal/executor/metrics/source/source.go
+++ b/internal/executor/metrics/source/source.go
@@ -1,0 +1,14 @@
+package source
+
+import (
+	"context"
+	"time"
+)
+
+type CPU interface {
+	NumCpusUsed(ctx context.Context, pollInterval time.Duration) (float64, error)
+}
+
+type Memory interface {
+	AmountMemoryUsed(ctx context.Context) (float64, error)
+}

--- a/internal/executor/metrics/source/system/system.go
+++ b/internal/executor/metrics/source/system/system.go
@@ -1,0 +1,38 @@
+package system
+
+import (
+	"context"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/mem"
+	"time"
+)
+
+type System struct{}
+
+func New() *System {
+	return &System{}
+}
+
+func (system *System) NumCpusUsed(ctx context.Context, pollInterval time.Duration) (float64, error) {
+	percentages, err := cpu.PercentWithContext(ctx, pollInterval, true)
+	if err != nil {
+		return 0, err
+	}
+
+	var numCpusUsed float64
+
+	for _, singleCpuUsageInPercents := range percentages {
+		numCpusUsed += singleCpuUsageInPercents / 100
+	}
+
+	return numCpusUsed, nil
+}
+
+func (system *System) AmountMemoryUsed(ctx context.Context) (float64, error) {
+	virtualMemoryStat, err := mem.VirtualMemoryWithContext(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return float64(virtualMemoryStat.Used), nil
+}


### PR DESCRIPTION
This approach completely disregards the notion of container, which gives the following benefits:

* no weird heuristic like checking for `docker` string in `/proc/self/croup` to determine if we're running inside of a container
* more precise resource reporting for Persistent Workers that are being resource-constrained using cgroup

Tested using `go run cmd/metrics/metrics.go` and compared against `htop`/`docker stats` on:

* Debian 10 running cgroup version 1 filesystem
  * on the host itself
  * inside of a Docker container
* Fedora 33 running cgroup version 2 filesystem
  * on the host itself
  * inside of a Docker container

Also tested against `kubectl top pods` on:

* GKE
  * COS with containerd
  * COS with Docker

Resolves #174.