### PR TITLE
ShellCommandsAndWait: don't wait for children processes

### DIFF
--- a/internal/executor/piper/piper.go
+++ b/internal/executor/piper/piper.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"runtime"
-	"time"
 )
 
 type Piper struct {
@@ -38,28 +36,14 @@ func (piper *Piper) Input() *os.File {
 }
 
 func (piper *Piper) Close() (result error) {
-	// Cancel the Goroutine started in New(): ungracefully Windows and gracefully for other platforms
-	if runtime.GOOS == "windows" {
-		result = piper.r.Close()
-	} else {
-		result = piper.r.SetReadDeadline(time.Now().Add(time.Millisecond * 100))
-	}
+	// Cancel the Goroutine started in New()
+	result = piper.r.Close()
 
-	isUngracefulWindowsTermination := func(err error) bool {
-		return runtime.GOOS == "windows" && errors.Is(err, os.ErrClosed)
-	}
-
-	if err := <-piper.errChan; err != nil && !isUngracefulWindowsTermination(err) && result == nil {
+	if err := <-piper.errChan; err != nil && !errors.Is(err, os.ErrClosed) && result == nil {
 		result = err
 	}
 
-	if runtime.GOOS != "windows" {
-		if err := piper.r.Close(); err != nil && result == nil {
-			result = err
-		}
-	}
-
-	if err := piper.w.Close(); err != nil && result == nil && !errors.Is(err, os.ErrClosed) {
+	if err := piper.w.Close(); err != nil && !errors.Is(err, os.ErrClosed) && result == nil {
 		result = err
 	}
 

--- a/internal/executor/piper/piper.go
+++ b/internal/executor/piper/piper.go
@@ -1,0 +1,55 @@
+package piper
+
+import (
+	"errors"
+	"io"
+	"os"
+	"time"
+)
+
+type Piper struct {
+	r, w *os.File
+	errChan chan error
+}
+
+func New(output io.Writer) (*Piper, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	piper := &Piper{
+		r: r,
+		w: w,
+		errChan: make(chan error),
+	}
+
+	go func() {
+		_, err := io.Copy(output, r)
+		piper.errChan <- err
+	}()
+
+	return piper, nil
+}
+
+func (piper *Piper) Input() *os.File {
+	return piper.w
+}
+
+func (piper *Piper) Close() (result error) {
+	result = piper.r.SetReadDeadline(time.Now().Add(time.Millisecond * 100))
+
+	if err := <-piper.errChan; err != nil && result == nil {
+		result = err
+	}
+
+	if err := piper.r.Close(); err != nil && result == nil {
+		result = err
+	}
+
+	if err := piper.w.Close(); err != nil && result == nil && !errors.Is(err, os.ErrClosed) {
+		result = err
+	}
+
+	return result
+}

--- a/internal/executor/piper/piper.go
+++ b/internal/executor/piper/piper.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Piper struct {
-	r, w *os.File
+	r, w    *os.File
 	errChan chan error
 }
 
@@ -19,8 +19,8 @@ func New(output io.Writer) (*Piper, error) {
 	}
 
 	piper := &Piper{
-		r: r,
-		w: w,
+		r:       r,
+		w:       w,
 		errChan: make(chan error),
 	}
 

--- a/internal/executor/shell_unix_test.go
+++ b/internal/executor/shell_unix_test.go
@@ -20,7 +20,7 @@ func TestProcessGroupTermination(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	success, output := ShellCommandsAndGetOutput(ctx, []string{"sleep 86400& echo target PID is $!; sleep 60"}, nil)
+	success, output := ShellCommandsAndGetOutput(ctx, []string{"sleep 86400 & echo target PID is $! ; sleep 60"}, nil)
 
 	assert.False(t, success, "the command should fail due to time out error")
 	assert.Contains(t, output, "Timed out!", "the command should time out")
@@ -135,4 +135,14 @@ func Test_ShellCommands_Timeout_Unix(t *testing.T) {
 	} else {
 		t.Errorf("Wrong output: '%s'", output)
 	}
+}
+
+func TestChildrenProcessesAreNotWaitedFor(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	success, output := ShellCommandsAndGetOutput(ctx, []string{"sleep 60 & sleep 1"}, nil)
+
+	assert.True(t, success)
+	assert.NotContains(t, output, "Timed out!")
 }

--- a/internal/executor/shellcommands.go
+++ b/internal/executor/shellcommands.go
@@ -3,12 +3,14 @@
 package executor
 
 import (
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/piper"
 	"os/exec"
 	"syscall"
 )
 
 type ShellCommands struct {
-	cmd *exec.Cmd
+	cmd   *exec.Cmd
+	piper *piper.Piper
 }
 
 func (sc *ShellCommands) afterStart() {

--- a/internal/executor/shellcommands_windows.go
+++ b/internal/executor/shellcommands_windows.go
@@ -1,12 +1,14 @@
 package executor
 
 import (
+	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/piper"
 	"golang.org/x/sys/windows"
 	"os/exec"
 )
 
 type ShellCommands struct {
 	cmd       *exec.Cmd
+	piper     *piper.Piper
 	jobHandle windows.Handle
 }
 


### PR DESCRIPTION
Resolves https://github.com/cirruslabs/cirrus-ci-docs/issues/910 by working around https://github.com/golang/go/issues/23019.

This issue was first spotted in https://github.com/cirruslabs/cirrus-ci-agent/issues/23, however, [the PR that fixed it](https://github.com/cirruslabs/cirrus-ci-agent/pull/135) only targets cases where the shell is terminated by a timeout and not cases where the shell has exited cleanly (yet left behind the descendants that referenced it's stderr/stdout file descriptors).