### PR TITLE
TerminalWrapper: make operationChan buffered (with 4096 values)

### DIFF
--- a/internal/executor/terminalwrapper/terminalwrapper.go
+++ b/internal/executor/terminalwrapper/terminalwrapper.go
@@ -23,7 +23,7 @@ type Wrapper struct {
 func New(ctx context.Context, taskIdentification *api.TaskIdentification, serverAddress string) *Wrapper {
 	wrapper := &Wrapper{
 		ctx:           ctx,
-		operationChan: make(chan Operation),
+		operationChan: make(chan Operation, 4096),
 	}
 
 	// A trusted secret that grants ability to spawn shells on the terminal host we start below


### PR DESCRIPTION
To avoid hangs here, for example:

https://github.com/cirruslabs/cirrus-ci-agent/blob/77a38a36c924f009f5445b0dda6b250a55daf25d/internal/executor/terminalwrapper/terminalwrapper.go#L71