### PR TITLE
Bump github.com/cirruslabs/terminal to 0.8.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
 	github.com/cirruslabs/cirrus-ci-annotations v0.3.0
-	github.com/cirruslabs/terminal v0.8.1
+	github.com/cirruslabs/terminal v0.8.2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/cirruslabs/cirrus-ci-agent v1.51.0/go.mod h1:lEH1v2tn22T359W3fGjiAcYA
 github.com/cirruslabs/cirrus-ci-annotations v0.3.0 h1:VDFzTvXZ5yi4KPTct4xNbAurnSpKJnzIXgbKoDWAZww=
 github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/terminal v0.2.5/go.mod h1:ubLe9fvd4FYeQV08ob5TNp9tsAfE0efkFtPrlKAwIKw=
-github.com/cirruslabs/terminal v0.8.1 h1:iJh5wYOSXu3wmszWLBmcW4QdHuAzOWJcA65BS5vlTQc=
-github.com/cirruslabs/terminal v0.8.1/go.mod h1:dJjeclmbllzeIveV2wiJyIwgK36bI/VRWgpKXWEKxAk=
+github.com/cirruslabs/terminal v0.8.2 h1:DBOycDzD4FBTkegsEjlKlBZzOFfwa0IaCfr5E5uydw4=
+github.com/cirruslabs/terminal v0.8.2/go.mod h1:dJjeclmbllzeIveV2wiJyIwgK36bI/VRWgpKXWEKxAk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=


### PR DESCRIPTION
To include https://github.com/cirruslabs/terminal/pull/19.