### PR TITLE
Bump github.com/cirruslabs/cirrus-ci-annotations to 0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
-	github.com/cirruslabs/cirrus-ci-annotations v0.4.0
+	github.com/cirruslabs/cirrus-ci-annotations v0.4.1-0.20211021072451-dde6d9363492
 	github.com/cirruslabs/terminal v0.8.2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
-	github.com/cirruslabs/cirrus-ci-annotations v0.4.1-0.20211021072451-dde6d9363492
+	github.com/cirruslabs/cirrus-ci-annotations v0.4.0
 	github.com/cirruslabs/terminal v0.8.2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
-	github.com/cirruslabs/cirrus-ci-annotations v0.4.0
+	github.com/cirruslabs/cirrus-ci-annotations v0.5.0
 	github.com/cirruslabs/terminal v0.8.2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/cirruslabs/cirrus-ci-agent v1.51.0/go.mod h1:lEH1v2tn22T359W3fGjiAcYA
 github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/cirrus-ci-annotations v0.4.0 h1:ENp2ntrp4JaGsKWNUzF/tT1CINZpAnSV9wxkrEqU9VU=
 github.com/cirruslabs/cirrus-ci-annotations v0.4.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
+github.com/cirruslabs/cirrus-ci-annotations v0.4.1-0.20211021072451-dde6d9363492 h1:qhZ24ZmmEs54opEQNCJou+3EctLlTPtposHR71Qe70c=
+github.com/cirruslabs/cirrus-ci-annotations v0.4.1-0.20211021072451-dde6d9363492/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/terminal v0.2.5/go.mod h1:ubLe9fvd4FYeQV08ob5TNp9tsAfE0efkFtPrlKAwIKw=
 github.com/cirruslabs/terminal v0.8.2 h1:DBOycDzD4FBTkegsEjlKlBZzOFfwa0IaCfr5E5uydw4=
 github.com/cirruslabs/terminal v0.8.2/go.mod h1:dJjeclmbllzeIveV2wiJyIwgK36bI/VRWgpKXWEKxAk=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d/go.mod h1:sGbDF6
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cirruslabs/cirrus-ci-agent v1.51.0/go.mod h1:lEH1v2tn22T359W3fGjiAcYAY6jsqz75eHc4teh2nCY=
 github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
-github.com/cirruslabs/cirrus-ci-annotations v0.4.0 h1:ENp2ntrp4JaGsKWNUzF/tT1CINZpAnSV9wxkrEqU9VU=
-github.com/cirruslabs/cirrus-ci-annotations v0.4.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
+github.com/cirruslabs/cirrus-ci-annotations v0.5.0 h1:crXzmbyi+YcB693sasGAEBFeSUI3dtsrh9soy6p7C5c=
+github.com/cirruslabs/cirrus-ci-annotations v0.5.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/terminal v0.2.5/go.mod h1:ubLe9fvd4FYeQV08ob5TNp9tsAfE0efkFtPrlKAwIKw=
 github.com/cirruslabs/terminal v0.8.2 h1:DBOycDzD4FBTkegsEjlKlBZzOFfwa0IaCfr5E5uydw4=
 github.com/cirruslabs/terminal v0.8.2/go.mod h1:dJjeclmbllzeIveV2wiJyIwgK36bI/VRWgpKXWEKxAk=

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,6 @@ github.com/cirruslabs/cirrus-ci-agent v1.51.0/go.mod h1:lEH1v2tn22T359W3fGjiAcYA
 github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/cirrus-ci-annotations v0.4.0 h1:ENp2ntrp4JaGsKWNUzF/tT1CINZpAnSV9wxkrEqU9VU=
 github.com/cirruslabs/cirrus-ci-annotations v0.4.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
-github.com/cirruslabs/cirrus-ci-annotations v0.4.1-0.20211021072451-dde6d9363492 h1:qhZ24ZmmEs54opEQNCJou+3EctLlTPtposHR71Qe70c=
-github.com/cirruslabs/cirrus-ci-annotations v0.4.1-0.20211021072451-dde6d9363492/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/terminal v0.2.5/go.mod h1:ubLe9fvd4FYeQV08ob5TNp9tsAfE0efkFtPrlKAwIKw=
 github.com/cirruslabs/terminal v0.8.2 h1:DBOycDzD4FBTkegsEjlKlBZzOFfwa0IaCfr5E5uydw4=
 github.com/cirruslabs/terminal v0.8.2/go.mod h1:dJjeclmbllzeIveV2wiJyIwgK36bI/VRWgpKXWEKxAk=

--- a/internal/executor/artifacts.go
+++ b/internal/executor/artifacts.go
@@ -50,7 +50,7 @@ func (executor *Executor) UploadArtifacts(
 
 	workingDir := customEnv["CIRRUS_WORKING_DIR"]
 	if len(allAnnotations) > 0 {
-		err := annotations.ValidateAnnotations(workingDir, allAnnotations)
+		allAnnotations, err = annotations.NormalizeAnnotations(workingDir, allAnnotations)
 		if err != nil {
 			logUploader.Write([]byte(fmt.Sprintf("\nFailed to validate annotations: %s", err)))
 		}

--- a/internal/executor/artifacts.go
+++ b/internal/executor/artifacts.go
@@ -25,7 +25,7 @@ func (executor *Executor) UploadArtifacts(
 	customEnv map[string]string,
 ) bool {
 	var err error
-	var allAnnotations []model.Annotation
+	var allAnnotations []*model.Annotation
 
 	if len(artifactsInstruction.Paths) == 0 {
 		logUploader.Write([]byte("\nSkipping artifacts upload because there are no path specified..."))
@@ -87,8 +87,8 @@ func (executor *Executor) uploadArtifactsAndParseAnnotations(
 	artifactsInstruction *api.ArtifactsInstruction,
 	customEnv map[string]string,
 	logUploader *LogUploader,
-) ([]model.Annotation, error) {
-	allAnnotations := make([]model.Annotation, 0)
+) ([]*model.Annotation, error) {
+	var allAnnotations []*model.Annotation
 
 	uploadArtifactsClient, err := client.CirrusClient.UploadArtifacts(ctx)
 	if err != nil {

--- a/internal/executor/artifacts.go
+++ b/internal/executor/artifacts.go
@@ -25,7 +25,7 @@ func (executor *Executor) UploadArtifacts(
 	customEnv map[string]string,
 ) bool {
 	var err error
-	var allAnnotations []*model.Annotation
+	var allAnnotations []model.Annotation
 
 	if len(artifactsInstruction.Paths) == 0 {
 		logUploader.Write([]byte("\nSkipping artifacts upload because there are no path specified..."))
@@ -87,8 +87,8 @@ func (executor *Executor) uploadArtifactsAndParseAnnotations(
 	artifactsInstruction *api.ArtifactsInstruction,
 	customEnv map[string]string,
 	logUploader *LogUploader,
-) ([]*model.Annotation, error) {
-	var allAnnotations []*model.Annotation
+) ([]model.Annotation, error) {
+	allAnnotations := make([]model.Annotation, 0)
 
 	uploadArtifactsClient, err := client.CirrusClient.UploadArtifacts(ctx)
 	if err != nil {

--- a/internal/executor/utils.go
+++ b/internal/executor/utils.go
@@ -57,7 +57,7 @@ func isDirEmpty(path string) bool {
 	return len(files) == 0
 }
 
-func ConvertAnnotations(annotations []*model.Annotation) []*api.Annotation {
+func ConvertAnnotations(annotations []model.Annotation) []*api.Annotation {
 	result := make([]*api.Annotation, 0)
 	for _, annotation := range annotations {
 		protoAnnotation := api.Annotation{

--- a/internal/executor/utils.go
+++ b/internal/executor/utils.go
@@ -57,7 +57,7 @@ func isDirEmpty(path string) bool {
 	return len(files) == 0
 }
 
-func ConvertAnnotations(annotations []model.Annotation) []*api.Annotation {
+func ConvertAnnotations(annotations []*model.Annotation) []*api.Annotation {
 	result := make([]*api.Annotation, 0)
 	for _, annotation := range annotations {
 		protoAnnotation := api.Annotation{


### PR DESCRIPTION
A proper tag will be set in `go.mod` once https://github.com/cirruslabs/cirrus-ci-annotations/pull/36 is merged.