### PR TITLE
Bump github.com/cirruslabs/cirrus-ci-annotations to 0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
-	github.com/cirruslabs/cirrus-ci-annotations v0.6.0
+	github.com/cirruslabs/cirrus-ci-annotations v0.7.0
 	github.com/cirruslabs/terminal v0.10.1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cirruslabs/cirrus-ci-agent v1.51.0/go.mod h1:lEH1v2tn22T359W3fGjiAcYAY6jsqz75eHc4teh2nCY=
 github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
-github.com/cirruslabs/cirrus-ci-annotations v0.6.0 h1:i5hfYSMlGP9GDzyYlBZXRCulcOav/J5mEPgTpta3YQw=
-github.com/cirruslabs/cirrus-ci-annotations v0.6.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
+github.com/cirruslabs/cirrus-ci-annotations v0.7.0 h1:tEtvcCcYgKU/NOCcppMizLwmTmNMTXoi7fqMUE/XOuw=
+github.com/cirruslabs/cirrus-ci-annotations v0.7.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/terminal v0.2.5/go.mod h1:ubLe9fvd4FYeQV08ob5TNp9tsAfE0efkFtPrlKAwIKw=
 github.com/cirruslabs/terminal v0.10.1 h1:0FrTDHxe9f7oVVQzeiHzoevnzuinGvT4CdtNhQ32C7g=
 github.com/cirruslabs/terminal v0.10.1/go.mod h1:5nVkiTg4y2ugDJjchuc9Lyz1cxu+KugFiJyuiESaYiY=


### PR DESCRIPTION
To include https://github.com/cirruslabs/cirrus-ci-annotations/pull/39.