### PR TITLE
Wait for the terminal server connection instead of a session + provide task's identification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
 	github.com/cirruslabs/cirrus-ci-annotations v0.7.0
-	github.com/cirruslabs/terminal v0.10.2-0.20211206135224-c0fa8c76b850
+	github.com/cirruslabs/terminal v0.10.2-0.20211206144640-9f749e4b65d7
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/golang/protobuf v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
 	github.com/cirruslabs/cirrus-ci-annotations v0.7.0
-	github.com/cirruslabs/terminal v0.10.1
+	github.com/cirruslabs/terminal v0.10.2-0.20211206135224-c0fa8c76b850
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/golang/protobuf v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
 	github.com/cirruslabs/cirrus-ci-annotations v0.7.0
-	github.com/cirruslabs/terminal v0.10.2-0.20211206144640-9f749e4b65d7
+	github.com/cirruslabs/terminal v0.11.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQE
 github.com/cirruslabs/cirrus-ci-annotations v0.7.0 h1:tEtvcCcYgKU/NOCcppMizLwmTmNMTXoi7fqMUE/XOuw=
 github.com/cirruslabs/cirrus-ci-annotations v0.7.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/terminal v0.2.5/go.mod h1:ubLe9fvd4FYeQV08ob5TNp9tsAfE0efkFtPrlKAwIKw=
-github.com/cirruslabs/terminal v0.10.2-0.20211206135224-c0fa8c76b850 h1:tAGabsciXVrT03SsesmqFp2oipFuI/bNgJUphImNCFg=
-github.com/cirruslabs/terminal v0.10.2-0.20211206135224-c0fa8c76b850/go.mod h1:5nVkiTg4y2ugDJjchuc9Lyz1cxu+KugFiJyuiESaYiY=
+github.com/cirruslabs/terminal v0.10.2-0.20211206144640-9f749e4b65d7 h1:AlOdqc4hgmyjxcMtmhoDE1M3RchIkKDVBi9Pm74jniE=
+github.com/cirruslabs/terminal v0.10.2-0.20211206144640-9f749e4b65d7/go.mod h1:5nVkiTg4y2ugDJjchuc9Lyz1cxu+KugFiJyuiESaYiY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQE
 github.com/cirruslabs/cirrus-ci-annotations v0.7.0 h1:tEtvcCcYgKU/NOCcppMizLwmTmNMTXoi7fqMUE/XOuw=
 github.com/cirruslabs/cirrus-ci-annotations v0.7.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/terminal v0.2.5/go.mod h1:ubLe9fvd4FYeQV08ob5TNp9tsAfE0efkFtPrlKAwIKw=
-github.com/cirruslabs/terminal v0.10.2-0.20211206144640-9f749e4b65d7 h1:AlOdqc4hgmyjxcMtmhoDE1M3RchIkKDVBi9Pm74jniE=
-github.com/cirruslabs/terminal v0.10.2-0.20211206144640-9f749e4b65d7/go.mod h1:5nVkiTg4y2ugDJjchuc9Lyz1cxu+KugFiJyuiESaYiY=
+github.com/cirruslabs/terminal v0.11.0 h1:iWnyoogTA9BreM7kL0iGaZuQ6ASH0eC45Vz1QEm3FoE=
+github.com/cirruslabs/terminal v0.11.0/go.mod h1:5nVkiTg4y2ugDJjchuc9Lyz1cxu+KugFiJyuiESaYiY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQE
 github.com/cirruslabs/cirrus-ci-annotations v0.7.0 h1:tEtvcCcYgKU/NOCcppMizLwmTmNMTXoi7fqMUE/XOuw=
 github.com/cirruslabs/cirrus-ci-annotations v0.7.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
 github.com/cirruslabs/terminal v0.2.5/go.mod h1:ubLe9fvd4FYeQV08ob5TNp9tsAfE0efkFtPrlKAwIKw=
-github.com/cirruslabs/terminal v0.10.1 h1:0FrTDHxe9f7oVVQzeiHzoevnzuinGvT4CdtNhQ32C7g=
-github.com/cirruslabs/terminal v0.10.1/go.mod h1:5nVkiTg4y2ugDJjchuc9Lyz1cxu+KugFiJyuiESaYiY=
+github.com/cirruslabs/terminal v0.10.2-0.20211206135224-c0fa8c76b850 h1:tAGabsciXVrT03SsesmqFp2oipFuI/bNgJUphImNCFg=
+github.com/cirruslabs/terminal v0.10.2-0.20211206135224-c0fa8c76b850/go.mod h1:5nVkiTg4y2ugDJjchuc9Lyz1cxu+KugFiJyuiESaYiY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/internal/executor/terminalwrapper/terminalwrapper.go
+++ b/internal/executor/terminalwrapper/terminalwrapper.go
@@ -113,7 +113,7 @@ func (wrapper *Wrapper) Wait() chan Operation {
 		}
 
 		// Wait for the terminal to connect, exit on ctx cancellation/deadline
-		if !wrapper.waitForSession() {
+		if !wrapper.waitForConnection() {
 			return
 		}
 
@@ -166,9 +166,9 @@ func (wrapper *Wrapper) Wait() chan Operation {
 	return wrapper.operationChan
 }
 
-func (wrapper *Wrapper) waitForSession() bool {
+func (wrapper *Wrapper) waitForConnection() bool {
 	wrapper.operationChan <- &LogOperation{
-		Message: "Waiting for the terminal session to be established...",
+		Message: "Waiting for the terminal server connection to be established...",
 	}
 
 	ticker := time.NewTicker(1 * time.Second)
@@ -178,7 +178,7 @@ func (wrapper *Wrapper) waitForSession() bool {
 		select {
 		case <-ticker.C:
 			defaultTime := time.Time{}
-			if wrapper.terminalHost.LastRegistration() != defaultTime {
+			if wrapper.terminalHost.LastConnection() != defaultTime {
 				return true
 			}
 		case <-wrapper.ctx.Done():


### PR DESCRIPTION
The rationale behind https://github.com/cirruslabs/cirrus-ci-agent/commit/78a57d84ccf1e58302bdfa95598da2c7c20da590 is explained in https://github.com/cirruslabs/terminal/pull/24, and https://github.com/cirruslabs/cirrus-ci-agent/commit/2fda044013c84afbfe828b509fa7b7f1d1c429ad fixes a bug.

Needs https://github.com/cirruslabs/terminal/pull/24 to be merged and released first.