### PR TITLE
Metrics: fail gracefully

### DIFF
--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -9,9 +9,13 @@ import (
 func main() {
 	logger := logrus.New()
 
-	_, errChan := metrics.Run(context.Background(), logger)
+	resultChan := metrics.Run(context.Background(), logger)
 
-	if err := <-errChan; err != nil {
-		logrus.Fatalf("metrics failed: %v", err)
+	result := <-resultChan
+
+	if len(result.Errors) != 0 {
+		for _, err := range result.Errors {
+			logrus.Fatalf("metrics failed: %v", err)
+		}
 	}
 }

--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -13,8 +13,8 @@ func main() {
 
 	result := <-resultChan
 
-	if len(result.Errors) != 0 {
-		for _, err := range result.Errors {
+	if len(result.Errors()) != 0 {
+		for _, err := range result.Errors() {
 			logrus.Fatalf("metrics failed: %v", err)
 		}
 	}

--- a/internal/executor/cmd.go
+++ b/internal/executor/cmd.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package executor

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -93,7 +93,7 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 	// Start collecting metrics
 	metricsCtx, metricsCancel := context.WithCancel(ctx)
 	defer metricsCancel()
-	metricsResultChan, metricsErrChan := metrics.Run(metricsCtx, nil)
+	metricsResultChan := metrics.Run(metricsCtx, nil)
 
 	log.Println("Getting initial commands...")
 
@@ -255,18 +255,14 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 	// Retrieve resource utilization metrics
 	metricsCancel()
 
-	var resourceUtilization *api.ResourceUtilization
+	var metricsResult *metrics.Result
 
 	select {
-	case result := <-metricsResultChan:
-		resourceUtilization = result
-	case err := <-metricsErrChan:
-		message := fmt.Sprintf("Failed to retrieve resource utilization metrics: %v", err)
-		log.Print(message)
-		_, _ = client.CirrusClient.ReportAgentWarning(ctx, &api.ReportAgentProblemRequest{
-			TaskIdentification: executor.taskIdentification,
-			Message:            message,
-		})
+	case metricsResult = <-metricsResultChan:
+		for _, err := range metricsResult.Errors {
+			message := fmt.Sprintf("Failed to retrieve resource utilization metrics: %v", err)
+			log.Print(message)
+		}
 	case <-time.After(3 * time.Second):
 		// Yes, we already use context.Context, but it seems that gopsutil is somewhat lacking it's support[1],
 		// so we err on the side of caution here.
@@ -285,7 +281,7 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 			_, err = client.CirrusClient.ReportAgentFinished(ctx, &api.ReportAgentFinishedRequest{
 				TaskIdentification:     executor.taskIdentification,
 				CacheRetrievalAttempts: executor.cacheAttempts.ToProto(),
-				ResourceUtilization:    resourceUtilization,
+				ResourceUtilization:    &metricsResult.ResourceUtilization,
 				CommandResults:         ub.History(),
 			})
 			return err

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -259,7 +259,7 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 
 	select {
 	case metricsResult := <-metricsResultChan:
-		for _, err := range metricsResult.Errors {
+		for _, err := range metricsResult.Errors() {
 			message := fmt.Sprintf("Encountered an error while gathering resource utilization metrics: %v", err)
 			log.Print(message)
 			_, _ = client.CirrusClient.ReportAgentWarning(ctx, &api.ReportAgentProblemRequest{

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -281,7 +281,7 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 			_, err = client.CirrusClient.ReportAgentFinished(ctx, &api.ReportAgentFinishedRequest{
 				TaskIdentification:     executor.taskIdentification,
 				CacheRetrievalAttempts: executor.cacheAttempts.ToProto(),
-				ResourceUtilization:    &metricsResult.ResourceUtilization,
+				ResourceUtilization:    metricsResult.ResourceUtilization,
 				CommandResults:         ub.History(),
 			})
 			return err

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -262,6 +262,10 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 		for _, err := range metricsResult.Errors {
 			message := fmt.Sprintf("Failed to retrieve resource utilization metrics: %v", err)
 			log.Print(message)
+			_, _ = client.CirrusClient.ReportAgentWarning(ctx, &api.ReportAgentProblemRequest{
+				TaskIdentification: executor.taskIdentification,
+				Message:            message,
+			})
 		}
 	case <-time.After(3 * time.Second):
 		// Yes, we already use context.Context, but it seems that gopsutil is somewhat lacking it's support[1],

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -260,7 +260,7 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 	select {
 	case metricsResult := <-metricsResultChan:
 		for _, err := range metricsResult.Errors {
-			message := fmt.Sprintf("Failed to retrieve resource utilization metrics: %v", err)
+			message := fmt.Sprintf("Encountered an error while gathering resource utilization metrics: %v", err)
 			log.Print(message)
 			_, _ = client.CirrusClient.ReportAgentWarning(ctx, &api.ReportAgentProblemRequest{
 				TaskIdentification: executor.taskIdentification,

--- a/internal/executor/metrics/metrics.go
+++ b/internal/executor/metrics/metrics.go
@@ -73,7 +73,7 @@ func Run(ctx context.Context, logger logrus.FieldLogger) (chan *api.ResourceUtil
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					resultChan <- result
 				} else {
-					errChan <- fmt.Errorf("%w: %v", ErrFailedToQueryCPU, err)
+					errChan <- fmt.Errorf("%w using %s: %v", ErrFailedToQueryCPU, cpuSource.Name(), err)
 				}
 				return
 			}
@@ -84,7 +84,7 @@ func Run(ctx context.Context, logger logrus.FieldLogger) (chan *api.ResourceUtil
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					resultChan <- result
 				} else {
-					errChan <- fmt.Errorf("%w: %v", ErrFailedToQueryMemory, err)
+					errChan <- fmt.Errorf("%w using %s: %v", ErrFailedToQueryMemory, memorySource.Name(), err)
 				}
 				return
 			}

--- a/internal/executor/metrics/metrics.go
+++ b/internal/executor/metrics/metrics.go
@@ -75,28 +75,28 @@ func Run(ctx context.Context, logger logrus.FieldLogger) chan *Result {
 		for {
 			// CPU usage
 			numCpusUsed, cpuErr := cpuSource.NumCpusUsed(ctx, pollInterval)
-			if err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if cpuErr != nil {
+				if errors.Is(cpuErr, context.Canceled) || errors.Is(cpuErr, context.DeadlineExceeded) {
 					resultChan <- result
 
 					return
 				}
 
 				result.Errors = append(result.Errors,
-					fmt.Errorf("%w using %s: %v", ErrFailedToQueryCPU, cpuSource.Name(), err))
+					fmt.Errorf("%w using %s: %v", ErrFailedToQueryCPU, cpuSource.Name(), cpuErr))
 			}
 
 			// Memory usage
 			amountMemoryUsed, memoryErr := memorySource.AmountMemoryUsed(ctx)
-			if err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if memoryErr != nil {
+				if errors.Is(memoryErr, context.Canceled) || errors.Is(memoryErr, context.DeadlineExceeded) {
 					resultChan <- result
 
 					return
 				}
 
 				result.Errors = append(result.Errors,
-					fmt.Errorf("%w using %s: %v", ErrFailedToQueryMemory, memorySource.Name(), err))
+					fmt.Errorf("%w using %s: %v", ErrFailedToQueryMemory, memorySource.Name(), memoryErr))
 			}
 
 			if logger != nil {

--- a/internal/executor/metrics/metrics.go
+++ b/internal/executor/metrics/metrics.go
@@ -1,3 +1,4 @@
+//go:build !windows || (!arm && !arm64)
 // +build !windows !arm,!arm64
 
 package metrics

--- a/internal/executor/metrics/metrics.go
+++ b/internal/executor/metrics/metrics.go
@@ -77,11 +77,11 @@ func Run(ctx context.Context, logger logrus.FieldLogger) chan *Result {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					resultChan <- result
 					return
-				} else {
-					numCpusUsed = -1.0
-					result.Errors = append(result.Errors,
-						fmt.Errorf("%w using %s: %v", ErrFailedToQueryCPU, cpuSource.Name(), err))
 				}
+
+				numCpusUsed = -1.0
+				result.Errors = append(result.Errors,
+					fmt.Errorf("%w using %s: %v", ErrFailedToQueryCPU, cpuSource.Name(), err))
 			}
 
 			// Memory usage
@@ -89,11 +89,11 @@ func Run(ctx context.Context, logger logrus.FieldLogger) chan *Result {
 			if err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					resultChan <- result
-				} else {
-					amountMemoryUsed = -1.0
-					result.Errors = append(result.Errors,
-						fmt.Errorf("%w using %s: %v", ErrFailedToQueryMemory, memorySource.Name(), err))
 				}
+
+				amountMemoryUsed = -1.0
+				result.Errors = append(result.Errors,
+					fmt.Errorf("%w using %s: %v", ErrFailedToQueryMemory, memorySource.Name(), err))
 			}
 
 			if logger != nil {

--- a/internal/executor/metrics/metrics_test.go
+++ b/internal/executor/metrics/metrics_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second + 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second+500*time.Millisecond)
 	defer cancel()
 
 	resultChan, errChan := metrics.Run(ctx, nil)

--- a/internal/executor/metrics/metrics_test.go
+++ b/internal/executor/metrics/metrics_test.go
@@ -2,6 +2,7 @@ package metrics_test
 
 import (
 	"context"
+	"fmt"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -12,13 +13,14 @@ func TestMetrics(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second+500*time.Millisecond)
 	defer cancel()
 
-	resultChan, errChan := metrics.Run(ctx, nil)
+	resultChan := metrics.Run(ctx, nil)
 
-	select {
-	case result := <-resultChan:
-		require.Len(t, result.CpuChart, 4)
-		require.Len(t, result.MemoryChart, 4)
-	case err := <-errChan:
-		require.Fail(t, "we should never get an error here, but got %v", err)
+	result := <-resultChan
+
+	for i, err := range result.Errors {
+		fmt.Printf("Error #%d: %v\n", i, err)
 	}
+	require.Empty(t, result.Errors, "we should never get errors here, but got %d", len(result.Errors))
+	require.Len(t, result.ResourceUtilization.CpuChart, 4)
+	require.Len(t, result.ResourceUtilization.MemoryChart, 4)
 }

--- a/internal/executor/metrics/metrics_test.go
+++ b/internal/executor/metrics/metrics_test.go
@@ -17,10 +17,10 @@ func TestMetrics(t *testing.T) {
 
 	result := <-resultChan
 
-	for i, err := range result.Errors {
+	for i, err := range result.Errors() {
 		fmt.Printf("Error #%d: %v\n", i, err)
 	}
-	require.Empty(t, result.Errors, "we should never get errors here, but got %d", len(result.Errors))
+	require.Empty(t, result.Errors(), "we should never get errors here, but got %d", len(result.Errors()))
 	require.Len(t, result.ResourceUtilization.CpuChart, 4)
 	require.Len(t, result.ResourceUtilization.MemoryChart, 4)
 }

--- a/internal/executor/metrics/metrics_unsupported.go
+++ b/internal/executor/metrics/metrics_unsupported.go
@@ -11,7 +11,7 @@ import (
 
 type Result struct {
 	Errors              []error
-	ResourceUtilization api.ResourceUtilization
+	ResourceUtilization *api.ResourceUtilization
 }
 
 func Run(ctx context.Context, logger logrus.FieldLogger) chan *Result {

--- a/internal/executor/metrics/metrics_unsupported.go
+++ b/internal/executor/metrics/metrics_unsupported.go
@@ -1,3 +1,4 @@
+//go:build (windows && arm) || (windows && arm64)
 // +build windows,arm windows,arm64
 
 package metrics

--- a/internal/executor/metrics/metrics_unsupported.go
+++ b/internal/executor/metrics/metrics_unsupported.go
@@ -10,8 +10,11 @@ import (
 )
 
 type Result struct {
-	Errors              []error
 	ResourceUtilization *api.ResourceUtilization
+}
+
+func (Result) Errors() []error {
+	return []error{}
 }
 
 func Run(ctx context.Context, logger logrus.FieldLogger) chan *Result {

--- a/internal/executor/metrics/metrics_unsupported.go
+++ b/internal/executor/metrics/metrics_unsupported.go
@@ -9,11 +9,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Run(ctx context.Context, logger logrus.FieldLogger) (chan *api.ResourceUtilization, chan error) {
-	resultChan := make(chan *api.ResourceUtilization, 1)
-	errChan := make(chan error, 1)
+type Result struct {
+	Errors              []error
+	ResourceUtilization api.ResourceUtilization
+}
+
+func Run(ctx context.Context, logger logrus.FieldLogger) chan *Result {
+	resultChan := make(chan *Result, 1)
 
 	resultChan <- nil
 
-	return resultChan, errChan
+	return resultChan
 }

--- a/internal/executor/metrics/source/cgroup/cpu/cpu_linux.go
+++ b/internal/executor/metrics/source/cgroup/cpu/cpu_linux.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/subsystem"
 	gopsutilcpu "github.com/shirou/gopsutil/cpu"
 	"math"
+	"runtime"
 	"time"
 )
 
@@ -91,6 +92,10 @@ func (cpu *VersionlessCPU) NumCpusUsed(ctx context.Context, pollInterval time.Du
 	numCpus := len(times)
 
 	return math.Min(100, math.Max(0, cgroupDelta/systemDelta)) * float64(numCpus), nil
+}
+
+func (cpu *VersionlessCPU) Name() string {
+	return fmt.Sprintf("cgroup CPU resolver on %s/%s", runtime.GOOS, runtime.GOARCH)
 }
 
 func contextAwareSleep(ctx context.Context, duration time.Duration) error {

--- a/internal/executor/metrics/source/cgroup/cpu/cpu_unsupported.go
+++ b/internal/executor/metrics/source/cgroup/cpu/cpu_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package cpu

--- a/internal/executor/metrics/source/cgroup/cpu/v1.go
+++ b/internal/executor/metrics/source/cgroup/cpu/v1.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cpu

--- a/internal/executor/metrics/source/cgroup/cpu/v2.go
+++ b/internal/executor/metrics/source/cgroup/cpu/v2.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package cpu

--- a/internal/executor/metrics/source/cgroup/memory/memory_linux.go
+++ b/internal/executor/metrics/source/cgroup/memory/memory_linux.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/resolver"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/metrics/source/cgroup/subsystem"
+	"runtime"
 )
 
 type VersionlessMemory struct {
@@ -36,6 +37,10 @@ func NewMemory(resolver resolver.Resolver) (source.Memory, error) {
 	}
 
 	return versionlessMemory, nil
+}
+
+func (cpu *VersionlessMemory) Name() string {
+	return fmt.Sprintf("cgroup memory resolver on %s/%s", runtime.GOOS, runtime.GOARCH)
 }
 
 func (memory *VersionlessMemory) AmountMemoryUsed(ctx context.Context) (float64, error) {

--- a/internal/executor/metrics/source/cgroup/memory/memory_unsupported.go
+++ b/internal/executor/metrics/source/cgroup/memory/memory_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package memory

--- a/internal/executor/metrics/source/cgroup/memory/v1.go
+++ b/internal/executor/metrics/source/cgroup/memory/v1.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package memory

--- a/internal/executor/metrics/source/cgroup/memory/v2.go
+++ b/internal/executor/metrics/source/cgroup/memory/v2.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package memory

--- a/internal/executor/metrics/source/cgroup/resolver/resolver_unsupported.go
+++ b/internal/executor/metrics/source/cgroup/resolver/resolver_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package resolver

--- a/internal/executor/metrics/source/source.go
+++ b/internal/executor/metrics/source/source.go
@@ -6,9 +6,11 @@ import (
 )
 
 type CPU interface {
+	Name() string
 	NumCpusUsed(ctx context.Context, pollInterval time.Duration) (float64, error)
 }
 
 type Memory interface {
+	Name() string
 	AmountMemoryUsed(ctx context.Context) (float64, error)
 }

--- a/internal/executor/metrics/source/system/system.go
+++ b/internal/executor/metrics/source/system/system.go
@@ -2,8 +2,10 @@ package system
 
 import (
 	"context"
+	"fmt"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
+	"runtime"
 	"time"
 )
 
@@ -35,4 +37,8 @@ func (system *System) AmountMemoryUsed(ctx context.Context) (float64, error) {
 	}
 
 	return float64(virtualMemoryStat.Used), nil
+}
+
+func (system *System) Name() string {
+	return fmt.Sprintf("gopsutil on %s/%s", runtime.GOOS, runtime.GOARCH)
 }

--- a/internal/executor/shell_linux_test.go
+++ b/internal/executor/shell_linux_test.go
@@ -1,3 +1,4 @@
+//go:build !windows || !freebsd
 // +build !windows !freebsd
 
 package executor

--- a/internal/executor/shell_unix_test.go
+++ b/internal/executor/shell_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package executor

--- a/internal/executor/shell_windows_test.go
+++ b/internal/executor/shell_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package executor

--- a/internal/executor/shellcommands.go
+++ b/internal/executor/shellcommands.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package executor

--- a/internal/signalfilter/signalfilter.go
+++ b/internal/signalfilter/signalfilter.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package signalfilter


### PR DESCRIPTION
~~As for the `-1.0`, we can convert these values to `null` right in the web UI and get something like this:~~

![Screen Shot 2021-12-21 at 01 37 54](https://user-images.githubusercontent.com/85709/146841985-f66fb913-9e77-4f4b-90dd-503b01753643.png)

~~Since we are removing the agent warning generation for metrics, such graph at least gives a glimpse that something is wrong and a "Debugging" modal window can be further investigated for the agent logs.~~

Resolves #196.