### PR TITLE
Don't hold the CIRRUS_ENV file open

### DIFF
--- a/internal/cirrusenv/cirrusenv_test.go
+++ b/internal/cirrusenv/cirrusenv_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestCirrusEnv(t *testing.T) {
+func TestCirrusEnvNormal(t *testing.T) {
 	ce, err := cirrusenv.New(42)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cirrusenv/cirrusenv_windows_test.go
+++ b/internal/cirrusenv/cirrusenv_windows_test.go
@@ -1,0 +1,24 @@
+package cirrusenv_test
+
+import (
+	"github.com/cirruslabs/cirrus-ci-agent/internal/cirrusenv"
+	"github.com/stretchr/testify/require"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestCirrusEnvConcurrentAccess(t *testing.T) {
+	ce, err := cirrusenv.New(42)
+	require.NoError(t, err)
+	defer ce.Close()
+
+	cmd := exec.Command("cmd.exe", "/c", "echo A=B> "+ce.Path())
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+
+	env, err := ce.Consume()
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"A": "B"}, env)
+}


### PR DESCRIPTION
Unfortunately using the `FILE_SHARE_WRITE` flag as suggested in https://github.com/cirruslabs/cirrus-ci-docs/issues/961 doesn't seem to help: [Go already sets this flag](https://github.com/golang/go/blob/16d6a5233a183be7264295c66167d35c689f9372/src/syscall/syscall_windows.go#L332) (I've additionally checked this using Process Monitor on Windows), but the regular `echo` still fails, supposedly because it needs to specify the `FILE_SHARE_WRITE` flag too.

Resolves https://github.com/cirruslabs/cirrus-ci-docs/issues/961.