### PR TITLE
Disable metrics on {Open,Net}BSD

### DIFF
--- a/internal/executor/metrics/metrics.go
+++ b/internal/executor/metrics/metrics.go
@@ -1,4 +1,4 @@
-//go:build !openbsd
+//go:build !(openbsd || netbsd)
 
 package metrics
 

--- a/internal/executor/metrics/metrics_test.go
+++ b/internal/executor/metrics/metrics_test.go
@@ -1,3 +1,5 @@
+//go:build !(openbsd || netbsd)
+
 package metrics_test
 
 import (

--- a/internal/executor/metrics/metrics_unsupported.go
+++ b/internal/executor/metrics/metrics_unsupported.go
@@ -1,4 +1,4 @@
-//go:build openbsd
+//go:build openbsd || netbsd
 
 package metrics
 

--- a/internal/executor/shell_subunix_test.go
+++ b/internal/executor/shell_subunix_test.go
@@ -1,0 +1,46 @@
+//go:build unix && !(openbsd || netbsd)
+
+package executor
+
+import (
+	"context"
+	"github.com/mitchellh/go-ps"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestProcessGroupTermination ensures that we terminate the whole process group that
+// the shell spawned in ShellCommandsAndGetOutput() has been placed into, thus killing
+// it's children processes.
+func TestProcessGroupTermination(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	success, output := ShellCommandsAndGetOutput(ctx, []string{"sleep 86400 & echo target PID is $! ; sleep 60"}, nil)
+
+	assert.False(t, success, "the command should fail due to time out error")
+	assert.Contains(t, output, "Timed out!", "the command should time out")
+
+	re := regexp.MustCompile(".*target PID is ([0-9]+).*")
+	matches := re.FindStringSubmatch(output)
+	if len(matches) != 2 {
+		t.Fatal("failed to find target PID")
+	}
+
+	pid, err := strconv.ParseInt(matches[1], 10, 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the zombie to be reaped by the init process
+	time.Sleep(5 * time.Second)
+
+	// Unfortunately go-ps error behavior differs depending on the OS,
+	// (missing process is an error on FreeBSD but there's no error on Linux),
+	// so we skip the check here
+	process, _ := ps.FindProcess(int(pid))
+	assert.Nil(t, process)
+}

--- a/internal/executor/shell_unix_test.go
+++ b/internal/executor/shell_unix_test.go
@@ -5,47 +5,11 @@ package executor
 
 import (
 	"context"
-	"github.com/mitchellh/go-ps"
 	"github.com/stretchr/testify/assert"
-	"regexp"
 	"runtime"
-	"strconv"
 	"testing"
 	"time"
 )
-
-// TestProcessGroupTermination ensures that we terminate the whole process group that
-// the shell spawned in ShellCommandsAndGetOutput() has been placed into, thus killing
-// it's children processes.
-func TestProcessGroupTermination(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-
-	success, output := ShellCommandsAndGetOutput(ctx, []string{"sleep 86400 & echo target PID is $! ; sleep 60"}, nil)
-
-	assert.False(t, success, "the command should fail due to time out error")
-	assert.Contains(t, output, "Timed out!", "the command should time out")
-
-	re := regexp.MustCompile(".*target PID is ([0-9]+).*")
-	matches := re.FindStringSubmatch(output)
-	if len(matches) != 2 {
-		t.Fatal("failed to find target PID")
-	}
-
-	pid, err := strconv.ParseInt(matches[1], 10, 32)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Wait for the zombie to be reaped by the init process
-	time.Sleep(5 * time.Second)
-
-	// Unfortunately go-ps error behavior differs depending on the OS,
-	// (missing process is an error on FreeBSD but there's no error on Linux),
-	// so we skip the check here
-	process, _ := ps.FindProcess(int(pid))
-	assert.Nil(t, process)
-}
 
 func TestZshDoesNotHang(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/executor/shell_unix_test.go
+++ b/internal/executor/shell_unix_test.go
@@ -6,6 +6,7 @@ package executor
 import (
 	"context"
 	"github.com/stretchr/testify/assert"
+	"os/exec"
 	"runtime"
 	"testing"
 	"time"
@@ -14,6 +15,10 @@ import (
 func TestZshDoesNotHang(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+
+	if _, err := exec.LookPath("zsh"); err != nil {
+		t.Skip("no Zsh found")
+	}
 
 	success, _ := ShellCommandsAndGetOutput(ctx, []string{"zsh -c 'echo \"a:b\" | read -d \":\" piece'"}, nil)
 	assert.True(t, success)


### PR DESCRIPTION
Ran tests on OpenBSD 7.0, should be the same for NetBSD since it goes hand in hand with OpenBSD in build constants.

Resolves #211.