### PR TITLE
Implement cache download/upload RPC fallback

### DIFF
--- a/internal/http_cache/rpc_fallback.go
+++ b/internal/http_cache/rpc_fallback.go
@@ -77,7 +77,7 @@ func uploadCacheEntryViaRPC(w http.ResponseWriter, r *http.Request, cacheKey str
 		return
 	}
 
-	buf := make([]byte, 10*1024*1024)
+	buf := make([]byte, 1024*1024)
 
 	for {
 		n, err := r.Body.Read(buf)

--- a/internal/http_cache/rpc_fallback.go
+++ b/internal/http_cache/rpc_fallback.go
@@ -1,0 +1,125 @@
+package http_cache
+
+import (
+	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/client"
+	"io"
+	"log"
+	"net/http"
+)
+
+func downloadCacheViaRPC(w http.ResponseWriter, r *http.Request, cacheKey string) {
+	cacheStream, err := client.CirrusClient.DownloadCache(r.Context(), &api.DownloadCacheRequest{
+		TaskIdentification: cirrusTaskIdentification,
+		CacheKey:           cacheKey,
+	})
+	if err != nil {
+		log.Printf("%s cache download initialization (RPC fallback) failed: %v\n", cacheKey, err)
+		w.WriteHeader(http.StatusNotFound)
+
+		return
+	}
+
+	for {
+		chunk, err := cacheStream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				log.Printf("%s cache download (RPC fallback) finished...\n", cacheKey)
+				w.WriteHeader(http.StatusOK)
+			} else {
+				log.Printf("%s cache download (RPC fallback) failed: %v\n", cacheKey, err)
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+
+			return
+		}
+
+		if chunk.RedirectUrl != "" {
+			log.Printf("%s cache download (RPC fallback) requested a redirect\n", cacheKey)
+			proxyDownloadFromURL(w, chunk.RedirectUrl)
+
+			return
+		}
+
+		if len(chunk.Data) == 0 {
+			continue
+		}
+
+		if _, err := w.Write(chunk.Data); err != nil {
+			log.Printf("%s cache download (RPC fallback) failed: %v\n", cacheKey, err)
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+	}
+}
+
+func uploadCacheEntryViaRPC(w http.ResponseWriter, r *http.Request, cacheKey string) {
+	uploadCacheClient, err := client.CirrusClient.UploadCache(r.Context())
+	if err != nil {
+		log.Printf("%s cache upload initialization (RPC fallback) failed: %v\n", cacheKey, err)
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	if err := uploadCacheClient.Send(&api.CacheEntry{
+		Value: &api.CacheEntry_Key{
+			Key: &api.CacheKey{
+				TaskIdentification: cirrusTaskIdentification,
+				CacheKey:           cacheKey,
+			},
+		},
+	}); err != nil {
+		log.Printf("%s cache upload (RPC fallback) failed: %v\n", cacheKey, err)
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	buf := make([]byte, 10*1024*1024)
+
+	for {
+		n, err := r.Body.Read(buf)
+		if err == io.EOF {
+			log.Printf("%s cache upload (RPC fallback) finished...\n", cacheKey)
+
+			break
+		}
+		if err != nil {
+			log.Printf("%s cache upload (RPC fallback) failed: %v\n", cacheKey, err)
+			w.WriteHeader(http.StatusBadRequest)
+
+			_, _ = uploadCacheClient.CloseAndRecv()
+
+			return
+		}
+
+		if n == 0 {
+			continue
+		}
+
+		err = uploadCacheClient.Send(&api.CacheEntry{
+			Value: &api.CacheEntry_Chunk{
+				Chunk: &api.DataChunk{
+					Data: buf[:n],
+				},
+			},
+		})
+		if err != nil {
+			log.Printf("%s cache upload (RPC fallback) failed: %v\n", cacheKey, err)
+			w.WriteHeader(http.StatusInternalServerError)
+
+			_, _ = uploadCacheClient.CloseAndRecv()
+
+			return
+		}
+	}
+
+	if _, err := uploadCacheClient.CloseAndRecv(); err != nil {
+		log.Printf("%s cache upload (RPC fallback) failed: %v\n", cacheKey, err)
+		w.WriteHeader(http.StatusInternalServerError)
+	} else {
+		w.WriteHeader(http.StatusCreated)
+	}
+}

--- a/internal/http_cache/rpc_fallback.go
+++ b/internal/http_cache/rpc_fallback.go
@@ -25,7 +25,6 @@ func downloadCacheViaRPC(w http.ResponseWriter, r *http.Request, cacheKey string
 		if err != nil {
 			if err == io.EOF {
 				log.Printf("%s cache download (RPC fallback) finished...\n", cacheKey)
-				w.WriteHeader(http.StatusOK)
 			} else {
 				log.Printf("%s cache download (RPC fallback) failed: %v\n", cacheKey, err)
 				w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Ability to download/upload cache over RPC was superseded in https://github.com/cirruslabs/cirrus-ci-agent/commit/655ef61a09e2174edee97c4e6a19203f891b47c8, but the CLI's executor still uses this method because it's too cumbersome to passthrough a HTTP server inside of a container from the CLI's side.

This should fix the https://github.com/cirruslabs/cirrus-cli/pull/486 build.