### PR TITLE
Piper: don't close the os.Pipe's read end until we read everything

### DIFF
--- a/internal/executor/shell.go
+++ b/internal/executor/shell.go
@@ -73,7 +73,7 @@ func ShellCommandsAndWait(ctx context.Context, scripts []string, custom_env *map
 
 		return cmd, TimeOutError
 	case <-done:
-		if err := sc.piper.Close(); err != nil {
+		if err := sc.piper.Close(false); err != nil {
 			if errors.Is(err, os.ErrDeadlineExceeded) {
 				if err := sc.kill(); err != nil {
 					handler([]byte(fmt.Sprintf("\nFailed to kill a partially completed shell session: %s", err)))
@@ -164,7 +164,7 @@ func NewShellCommands(scripts []string, custom_env *map[string]string, handler S
 
 	err = cmd.Start()
 	if err != nil {
-		if err := sc.piper.Close(); err != nil {
+		if err := sc.piper.Close(true); err != nil {
 			_, _ = fmt.Fprintf(writer, "Shell session I/O error: %s", err)
 		}
 


### PR DESCRIPTION
After analyzing the https://github.com/cirruslabs/cirrus-ci-agent/pull/214 and fiddling with `os.Pipe` a bit, I've realized that:

1. we currently kill the pipe reading Goroutine prematurely by closing the pipe's read end: https://github.com/cirruslabs/cirrus-ci-agent/blob/d6db03925baaff71707eaec03f9ec80b990eb3f5/internal/executor/piper/piper.go#L40
2. we should instead manage to close all the writing end's copies to get all the data and a proper `EOF`

However, the bigger issue is that we're a bit at loss when it comes to making sure all the writing end's copies are closed, because:

1. we pass the writing end to the arbitrary process
2. it may spawn children which may detach from itself
3. we will then fail to kill that children and it'll keep the writing end open indefinitely, thus forcing us to wait in `Piper.Close() here: https://github.com/cirruslabs/cirrus-ci-agent/blob/d6db03925baaff71707eaec03f9ec80b990eb3f5/internal/executor/shell.go#L76