### PR TITLE
Improve Piper Closing

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -495,7 +495,7 @@ func (executor *Executor) ExecuteScriptsAndStreamLogs(
 	scripts []string,
 	env map[string]string,
 ) (*exec.Cmd, error) {
-	sc, err := NewShellCommands(scripts, &env, func(bytes []byte) (int, error) {
+	sc, err := NewShellCommands(ctx, scripts, &env, func(bytes []byte) (int, error) {
 		return logUploader.Write(bytes)
 	})
 	var cmd *exec.Cmd

--- a/internal/executor/shell.go
+++ b/internal/executor/shell.go
@@ -39,7 +39,7 @@ func ShellCommandsAndGetOutput(ctx context.Context, scripts []string, custom_env
 
 // return true if executed successful
 func ShellCommandsAndWait(ctx context.Context, scripts []string, custom_env *map[string]string, handler ShellOutputHandler) (*exec.Cmd, error) {
-	sc, err := NewShellCommands(scripts, custom_env, handler)
+	sc, err := NewShellCommands(ctx, scripts, custom_env, handler)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func ShellCommandsAndWait(ctx context.Context, scripts []string, custom_env *map
 
 		return cmd, TimeOutError
 	case <-done:
-		if err := sc.piper.Close(false); err != nil {
+		if err := sc.piper.Close(ctx); err != nil {
 			if errors.Is(err, os.ErrDeadlineExceeded) {
 				if err := sc.kill(); err != nil {
 					handler([]byte(fmt.Sprintf("\nFailed to kill a partially completed shell session: %s", err)))
@@ -99,7 +99,7 @@ func ShellCommandsAndWait(ctx context.Context, scripts []string, custom_env *map
 	}
 }
 
-func NewShellCommands(scripts []string, custom_env *map[string]string, handler ShellOutputHandler) (*ShellCommands, error) {
+func NewShellCommands(ctx context.Context, scripts []string, custom_env *map[string]string, handler ShellOutputHandler) (*ShellCommands, error) {
 	var cmd *exec.Cmd
 	var scriptFile *os.File
 	var err error
@@ -164,7 +164,7 @@ func NewShellCommands(scripts []string, custom_env *map[string]string, handler S
 
 	err = cmd.Start()
 	if err != nil {
-		if err := sc.piper.Close(true); err != nil {
+		if err := sc.piper.Close(ctx); err != nil {
 			_, _ = fmt.Fprintf(writer, "Shell session I/O error: %s", err)
 		}
 

--- a/internal/executor/shell_unix_test.go
+++ b/internal/executor/shell_unix_test.go
@@ -111,8 +111,9 @@ func TestChildrenProcessesAreNotWaitedFor(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	success, output := ShellCommandsAndGetOutput(ctx, []string{"sleep 60 & sleep 1"}, nil)
+	success, output := ShellCommandsAndGetOutput(ctx, []string{"sleep 60 &", "exit 0"}, nil)
 
 	assert.True(t, success)
 	assert.NotContains(t, output, "Timed out!")
+	assert.NotContains(t, output, "error")
 }


### PR DESCRIPTION
Follow up to #215 with the idea from #214

I tested changes from #215 with integration tests in Cirrus Cloud and found out that `daemon` integration tests is failing. With further investigation it appeared that we have a similar test in the agent which is passing but actually should've been failing (test is running for 1 minute and doesn't respect the `ctx`'s timeout).

In order to improve the tests I started passing `ctx` and properly log such errors. After that I reapplied the idea from #214 and everything seems to be working fine. 