### PR TITLE
Metrics: return empty Result instead of nil on {Open,Net}BSD

### DIFF
--- a/internal/executor/metrics/metrics_unsupported.go
+++ b/internal/executor/metrics/metrics_unsupported.go
@@ -19,7 +19,7 @@ func (Result) Errors() []error {
 func Run(ctx context.Context, logger logrus.FieldLogger) chan *Result {
 	resultChan := make(chan *Result, 1)
 
-	resultChan <- nil
+	resultChan <- &Result{}
 
 	return resultChan
 }


### PR DESCRIPTION
See https://github.com/cirruslabs/cirrus-ci-docs/issues/970#issuecomment-1060408788.