### PR TITLE
Don't forget to close body

### DIFF
--- a/internal/http_cache/rpc_fallback.go
+++ b/internal/http_cache/rpc_fallback.go
@@ -47,7 +47,7 @@ func downloadCacheViaRPC(w http.ResponseWriter, r *http.Request, cacheKey string
 
 		if chunk.RedirectUrl != "" {
 			log.Printf("%s cache download (RPC fallback) requested a redirect\n", cacheKey)
-			proxyDownloadFromURL(w, []string{chunk.RedirectUrl})
+			proxyDownloadFromURLs(w, []string{chunk.RedirectUrl})
 
 			return
 		}


### PR DESCRIPTION
It appeared we forgot to close `Body` of a request which will make the client not to reuse connection in case there are consecutive requests. 

Lame bug which I found while looking if there are some improvements we can do on the agent side for https://github.com/cirruslabs/cirrus-ci-docs/discussions/986