### PR TITLE
Configure max allowed idle connections

### DIFF
--- a/internal/http_cache/http_cache.go
+++ b/internal/http_cache/http_cache.go
@@ -38,9 +38,12 @@ func Start(taskIdentification *api.TaskIdentification) string {
 
 	certPool, err := gocertifi.CACerts()
 	if err == nil {
+		maxConcurrentConnections := runtime.NumCPU() * activeRequestsPerLogicalCPU
 		httpProxyClient = &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{RootCAs: certPool},
+				TLSClientConfig:     &tls.Config{RootCAs: certPool},
+				MaxIdleConns:        maxConcurrentConnections,
+				MaxIdleConnsPerHost: maxConcurrentConnections, // default is 2 which is too small
 			},
 			Timeout: time.Minute,
 		}


### PR DESCRIPTION
By default there is only 2 idle connections per post. In our case most likely there will be only one host to proxy cache from. Let's set `MaxIdleConnsPerHost` accordingly.