### PR TITLE
Rate-limit signal reporting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	golang.org/x/net v0.0.0-20220107192237-5cfca573fb4d
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/grpc v1.41.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -477,6 +477,7 @@ golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/signalfilter/signalfilter.go
+++ b/internal/signalfilter/signalfilter.go
@@ -8,6 +8,8 @@ import (
 	"syscall"
 )
 
+// IsNoisy determines which signals provide too much noise both for the text logs
+// and the RPC with little debugging value.
 func IsNoisy(sig os.Signal) bool {
 	return sig == syscall.SIGURG || sig == syscall.SIGCHLD
 }


### PR DESCRIPTION
Found a huge agent log with a bunch of entries like:

```
2022/04/02 08:52:57 Captured broken pipe...
2022/04/02 08:52:57 Captured broken pipe...
2022/04/02 08:52:57 Captured broken pipe...
2022/04/02 08:52:57 Captured broken pipe...
2022/04/02 08:52:57 Captured broken pipe...
2022/04/02 08:52:57 Captured broken pipe...
2022/04/02 08:52:57 Captured broken pipe...
2022/04/02 08:52:57 Captured broken pipe...
2022/04/02 08:52:57 Captured broken pipe...
```

Even through it's still unclear what causes this (the agent in question was used to develop https://github.com/cirruslabs/cirrus-cli/pull/493), it makes sense to limit signal reporting just in case.