### PR TITLE
No need to limit the cache size on agent side

### DIFF
--- a/internal/executor/cache.go
+++ b/internal/executor/cache.go
@@ -426,11 +426,6 @@ func (executor *Executor) UploadCache(
 		logUploader.Write([]byte(fmt.Sprintf("\n%s cache size is %dMb.", instruction.CacheName, bytesToUpload/1024/1024)))
 	}
 
-	if bytesToUpload >= 2*1000*1000*1000 {
-		logUploader.Write([]byte(fmt.Sprintf("\nCache %s is too big! Skipping caching...", commandName)))
-		return true
-	}
-
 	if !cache.CacheAvailable {
 		// check if some other task has uploaded the cache already
 		url := fmt.Sprintf("http://%s/%s", cacheHost, cache.Key)


### PR DESCRIPTION
We moved to uploading/downloading caches via pre-signed URLs. Such URLs contain size limits set by the Cirrus Cloud (5GB for community and no limit for self-hosted). Uploads will fail if someone will try to upload more data than the limit.

Relates to https://github.com/cirruslabs/cirrus-ci-docs/issues/1010