### PR TITLE
Allow other users to read the script file

### DIFF
--- a/internal/executor/utils.go
+++ b/internal/executor/utils.go
@@ -18,7 +18,7 @@ func TempFileName(prefix, suffix string) (*os.File, error) {
 	for i := 0; i < 10000; i++ {
 		rand.Read(randBytes)
 		path := filepath.Join(os.TempDir(), prefix+hex.EncodeToString(randBytes)+suffix)
-		f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+		f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
 		if os.IsExist(err) {
 			continue
 		}


### PR DESCRIPTION
I was trying to use `sudo -Hu ubuntu bash` as `CIRRUS_SHELL` so that everything is run under `ubuntu` user rather than `root` but this is currently not possible due to the set permissions:
```
bash: /tmp/scripts52fdfc072182654f163f5f0f9a621d72.sh: Permission denied

Exit status: 126
```