### PR TITLE
Bump timeouts for HTTP clients used for caching

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -20,7 +20,6 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/keepalive"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -221,7 +220,7 @@ func uploadAgentLogs(ctx context.Context, logFilePath string, taskId int64, clie
 		return
 	}
 
-	logContents, readErr := ioutil.ReadFile(logFilePath)
+	logContents, readErr := os.ReadFile(logFilePath)
 	if readErr != nil {
 		return
 	}

--- a/internal/cirrusenv/cirrusenv_test.go
+++ b/internal/cirrusenv/cirrusenv_test.go
@@ -3,7 +3,7 @@ package cirrusenv_test
 import (
 	"github.com/cirruslabs/cirrus-ci-agent/internal/cirrusenv"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -14,7 +14,7 @@ func TestCirrusEnvNormal(t *testing.T) {
 	}
 	defer ce.Close()
 
-	if err := ioutil.WriteFile(ce.Path(), []byte("A=B\nA==B"), 0600); err != nil {
+	if err := os.WriteFile(ce.Path(), []byte("A=B\nA==B"), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/executor/cache.go
+++ b/internal/executor/cache.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cirruslabs/cirrus-ci-agent/internal/hasher"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/http_cache"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/targz"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -294,7 +293,7 @@ func FetchCache(
 	cacheHost string,
 	cacheKey string,
 ) (*os.File, time.Duration, error) {
-	cacheFile, err := ioutil.TempFile(os.TempDir(), commandName)
+	cacheFile, err := os.CreateTemp(os.TempDir(), commandName)
 	if err != nil {
 		log.Printf("Failed to create a temp file %s: %v\n", commandName, err)
 		logUploader.Write([]byte(fmt.Sprintf("\nCache miss for %s!", commandName)))
@@ -401,7 +400,7 @@ func (executor *Executor) UploadCache(
 		}
 	}
 
-	cacheFile, err := ioutil.TempFile("", "")
+	cacheFile, err := os.CreateTemp("", "")
 	if err != nil {
 		logUploader.Write([]byte(fmt.Sprintf("\nFailed to create temporary cache file: %v", err)))
 		return false

--- a/internal/executor/cache.go
+++ b/internal/executor/cache.go
@@ -35,7 +35,7 @@ type Cache struct {
 var caches = make([]Cache, 0)
 
 var httpClient = &http.Client{
-	Timeout: time.Minute * 5,
+	Timeout: 10 * time.Minute,
 }
 
 func (executor *Executor) DownloadCache(

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -19,7 +19,6 @@ import (
 	gitclient "github.com/go-git/go-git/v5/plumbing/transport/client"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"golang.org/x/net/context"
-	"io/ioutil"
 	"log"
 	"math"
 	"net/http"
@@ -344,7 +343,7 @@ func getExpandedScriptEnvironment(executor *Executor, responseEnvironment map[st
 			// Default folder exists and we continue execution. Therefore we need to use it.
 			responseEnvironment["CIRRUS_WORKING_DIR"] = filepath.ToSlash(defaultTempDirPath)
 		} else {
-			uniqueTempDirPath, _ := ioutil.TempDir(os.TempDir(), fmt.Sprintf("cirrus-task-%d", executor.taskIdentification.TaskId))
+			uniqueTempDirPath, _ := os.MkdirTemp(os.TempDir(), fmt.Sprintf("cirrus-task-%d", executor.taskIdentification.TaskId))
 			responseEnvironment["CIRRUS_WORKING_DIR"] = filepath.ToSlash(uniqueTempDirPath)
 		}
 	}
@@ -525,7 +524,7 @@ func (executor *Executor) CreateFile(
 		}
 		filePath := ExpandText(instruction.DestinationPath, env)
 		EnsureFolderExists(filepath.Dir(filePath))
-		err := ioutil.WriteFile(filePath, []byte(content), 0644)
+		err := os.WriteFile(filePath, []byte(content), 0644)
 		if err != nil {
 			logUploader.Write([]byte(fmt.Sprintf("Failed to write file %s: %s!", filePath, err)))
 			return false

--- a/internal/executor/logs.go
+++ b/internal/executor/logs.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding/gzip"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -43,7 +42,7 @@ func NewLogUploader(ctx context.Context, executor *Executor, commandName string)
 		return nil, err
 	}
 	EnsureFolderExists(os.TempDir())
-	file, err := ioutil.TempFile(os.TempDir(), commandName)
+	file, err := os.CreateTemp(os.TempDir(), commandName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/executor/utils.go
+++ b/internal/executor/utils.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-ci-annotations/model"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -47,7 +46,7 @@ func allDirsEmpty(paths []string) bool {
 }
 
 func isDirEmpty(path string) bool {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if os.IsNotExist(err) {
 		return true
 	}

--- a/internal/hasher/hasher_test.go
+++ b/internal/hasher/hasher_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/cirruslabs/cirrus-ci-agent/internal/hasher"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/testutil"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -29,21 +29,21 @@ func TestDiffWithNewer(t *testing.T) {
 		{
 			Name: "no change",
 			OldFiller: func(dir string) {
-				ioutil.WriteFile(filepath.Join(dir, "same.txt"), []byte("same contents"), 0600)
+				os.WriteFile(filepath.Join(dir, "same.txt"), []byte("same contents"), 0600)
 			},
 			NewFiller: func(dir string) {
-				ioutil.WriteFile(filepath.Join(dir, "same.txt"), []byte("same contents"), 0600)
+				os.WriteFile(filepath.Join(dir, "same.txt"), []byte("same contents"), 0600)
 			},
 			Difference: []hasher.DiffEntry(nil),
 		},
 		{
 			Name: "file creation",
 			OldFiller: func(dir string) {
-				ioutil.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
+				os.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
 			},
 			NewFiller: func(dir string) {
-				ioutil.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
-				ioutil.WriteFile(filepath.Join(dir, "creation.txt"), []byte(""), 0600)
+				os.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
+				os.WriteFile(filepath.Join(dir, "creation.txt"), []byte(""), 0600)
 			},
 			Difference: []hasher.DiffEntry{
 				{hasher.Created, "creation.txt"},
@@ -52,12 +52,12 @@ func TestDiffWithNewer(t *testing.T) {
 		{
 			Name: "file modification",
 			OldFiller: func(dir string) {
-				ioutil.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
-				ioutil.WriteFile(filepath.Join(dir, "modification.txt"), []byte("old contents"), 0600)
+				os.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
+				os.WriteFile(filepath.Join(dir, "modification.txt"), []byte("old contents"), 0600)
 			},
 			NewFiller: func(dir string) {
-				ioutil.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
-				ioutil.WriteFile(filepath.Join(dir, "modification.txt"), []byte("new contents"), 0600)
+				os.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
+				os.WriteFile(filepath.Join(dir, "modification.txt"), []byte("new contents"), 0600)
 			},
 			Difference: []hasher.DiffEntry{
 				{hasher.Modified, "modification.txt"},
@@ -66,11 +66,11 @@ func TestDiffWithNewer(t *testing.T) {
 		{
 			Name: "file deletion",
 			OldFiller: func(dir string) {
-				ioutil.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
-				ioutil.WriteFile(filepath.Join(dir, "deletion.txt"), []byte("old contents"), 0600)
+				os.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
+				os.WriteFile(filepath.Join(dir, "deletion.txt"), []byte("old contents"), 0600)
 			},
 			NewFiller: func(dir string) {
-				ioutil.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
+				os.WriteFile(filepath.Join(dir, "control.txt"), []byte("control sample"), 0600)
 			},
 			Difference: []hasher.DiffEntry{
 				{hasher.Deleted, "deletion.txt"},

--- a/internal/http_cache/http_cache.go
+++ b/internal/http_cache/http_cache.go
@@ -45,7 +45,7 @@ func Start(taskIdentification *api.TaskIdentification) string {
 				MaxIdleConns:        maxConcurrentConnections,
 				MaxIdleConnsPerHost: maxConcurrentConnections, // default is 2 which is too small
 			},
-			Timeout: time.Minute,
+			Timeout: 10 * time.Minute,
 		}
 	}
 

--- a/internal/targz/targz_test.go
+++ b/internal/targz/targz_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cirruslabs/cirrus-ci-agent/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,7 +46,7 @@ func TarGzContentsHelper(t *testing.T, path string) []PartialTarHeader {
 			t.Fatal(err)
 		}
 
-		contents, err := ioutil.ReadAll(tarReader)
+		contents, err := io.ReadAll(tarReader)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -75,7 +74,7 @@ func TestArchive(t *testing.T) {
 			{tar.TypeDir, "", "", []byte{}},
 		}},
 		{"single file", func(dir string) {
-			ioutil.WriteFile(filepath.Join(dir, "file.txt"), []byte("contents"), 0600)
+			os.WriteFile(filepath.Join(dir, "file.txt"), []byte("contents"), 0600)
 		}, []PartialTarHeader{
 			{tar.TypeDir, "", "", []byte{}},
 			{tar.TypeReg, "/file.txt", "", []byte("contents")},
@@ -83,7 +82,7 @@ func TestArchive(t *testing.T) {
 		{"file inside of a directory", func(dir string) {
 			subDir := filepath.Join(dir, "sub-directory")
 			os.Mkdir(subDir, 0700)
-			ioutil.WriteFile(filepath.Join(subDir, "file.txt"), []byte("contents"), 0600)
+			os.WriteFile(filepath.Join(subDir, "file.txt"), []byte("contents"), 0600)
 		}, []PartialTarHeader{
 			{tar.TypeDir, "", "", []byte{}},
 			{tar.TypeDir, "/sub-directory", "", []byte{}},
@@ -142,7 +141,7 @@ func TestArchiveMultiple(t *testing.T) {
 	subFolder2 := filepath.Join(baseFolder, "right", "cold")
 	os.MkdirAll(subFolder2, 0700)
 
-	ioutil.WriteFile(filepath.Join(baseFolder, "should-not-be-included.txt"), []byte("doesn't matter"), 0600)
+	os.WriteFile(filepath.Join(baseFolder, "should-not-be-included.txt"), []byte("doesn't matter"), 0600)
 
 	// Make up a place where the archive will be stored
 	dest := filepath.Join(testutil.TempDir(t), "archive.tar.gz")

--- a/internal/testutil/fs.go
+++ b/internal/testutil/fs.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -9,7 +8,7 @@ import (
 // tempDir supplements an alternative to TB.TempDir()[1], which is only available in 1.15.
 // [1]: https://github.com/golang/go/issues/35998
 func TempDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Plus use the same value for Cirrus HTTP cache and the regular cache instructions.