### PR TITLE
Introduce CIRRUS_WINDOWS_ERROR_MODE environment variable

### DIFF
--- a/internal/executor/shell.go
+++ b/internal/executor/shell.go
@@ -167,6 +167,10 @@ func NewShellCommands(
 	cmd.Stderr = sc.piper.FileProxy()
 	cmd.Stdout = sc.piper.FileProxy()
 
+	if err := sc.beforeStart(custom_env); err != nil {
+		return nil, err
+	}
+
 	err = cmd.Start()
 	if err != nil {
 		if err := sc.piper.Close(ctx, true); err != nil {

--- a/internal/executor/shellcommands.go
+++ b/internal/executor/shellcommands.go
@@ -4,6 +4,7 @@
 package executor
 
 import (
+	"github.com/cirruslabs/cirrus-ci-agent/internal/environment"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/piper"
 	"os/exec"
 	"syscall"
@@ -12,6 +13,12 @@ import (
 type ShellCommands struct {
 	cmd   *exec.Cmd
 	piper *piper.Piper
+}
+
+func (sc *ShellCommands) beforeStart(env *environment.Environment) error {
+	// only used on Windows
+
+	return nil
 }
 
 func (sc *ShellCommands) afterStart() {

--- a/internal/executor/shellcommands_windows.go
+++ b/internal/executor/shellcommands_windows.go
@@ -1,18 +1,53 @@
 package executor
 
 import (
+	"errors"
+	"fmt"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/environment"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/piper"
 	"golang.org/x/sys/windows"
 	"os/exec"
+	"strconv"
+	"strings"
 )
 
 type ShellCommands struct {
-	cmd       *exec.Cmd
-	piper     *piper.Piper
-	jobHandle windows.Handle
+	cmd            *exec.Cmd
+	piper          *piper.Piper
+	jobHandle      windows.Handle
+	savedErrorMode uint32
+}
+
+var ErrInvalidWindowsErrorMode = errors.New("invalid CIRRUS_WINDOWS_ERROR_MODE value")
+
+func (sc *ShellCommands) beforeStart(env *environment.Environment) error {
+	errorModeRaw, ok := env.Lookup("CIRRUS_WINDOWS_ERROR_MODE")
+	if !ok {
+		return nil
+	}
+
+	if !strings.HasPrefix(errorModeRaw, "0x") {
+		return fmt.Errorf("%w: should start with 0x", ErrInvalidWindowsErrorMode)
+	}
+	errorModeRaw = strings.TrimPrefix(errorModeRaw, "0x")
+
+	errorMode, err := strconv.ParseUint(errorModeRaw, 16, 32)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidWindowsErrorMode, err)
+	}
+
+	// Set the error mode for the child process to use
+	// to work around Golang's disableWER() function[1]
+	// [1]: https://github.com/golang/go/issues/9121
+	sc.savedErrorMode = windows.SetErrorMode(uint32(errorMode))
+
+	return nil
 }
 
 func (sc *ShellCommands) afterStart() {
+	// Restore the original error mode
+	windows.SetErrorMode(sc.savedErrorMode)
+
 	jobHandle, err := windows.CreateJobObject(nil, nil)
 	if err != nil {
 		return


### PR DESCRIPTION
Manually tested on GCP machine using a Rust binary calling [`kernel32::GetErrorMode()`](https://docs.rs/kernel32-sys/0.2.2/x86_64-pc-windows-gnu/kernel32/fn.GetErrorMode.html).

See https://github.com/cirruslabs/cirrus-ci-docs/issues/1068.