### PR TITLE
Use merge reference instead of head

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -591,7 +591,7 @@ func (executor *Executor) CloneRepository(
 			return false
 		}
 
-		refSpec := fmt.Sprintf("+refs/pull/%s/head:refs/remotes/origin/pull/%[1]s", pr_number)
+		refSpec := fmt.Sprintf("+refs/pull/%s/merge:refs/remotes/origin/pull/%[1]s", pr_number)
 		logUploader.Write([]byte(fmt.Sprintf("\nFetching %s...\n", refSpec)))
 		fetchOptions := &git.FetchOptions{
 			RemoteName: remoteConfig.Name,


### PR DESCRIPTION
GH's `checkout` action [seems to use this reference for clones](https://github.com/actions/checkout/blob/eb8a193c1dbf4bbb2053320cef52bacc1a485839/__test__/ref-helper.test.ts#L50-L58).

See https://stackoverflow.com/questions/63594658/git-refs-merge-vs-head-in-pull-request