### PR TITLE
Adjust clone depth for PRs

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -600,7 +600,8 @@ func (executor *Executor) CloneRepository(
 			Progress:   logUploader,
 		}
 		if clone_depth > 0 {
-			fetchOptions.Depth = clone_depth
+			// increase by one since we are cloning with an extra "merge" commit from GH
+			fetchOptions.Depth = clone_depth + 1
 		}
 		err = repo.FetchContext(ctx, fetchOptions)
 		if err != nil && retryableCloneError(err) {


### PR DESCRIPTION
Since the recent change in #247

Otherwise it fails with CIRRUS_CLONE_DEPTH is set to 1 which we don't recommend but people do it.