### PR TITLE
Fix Vault's missing X.509 root certificates

### DIFF
--- a/internal/executor/vaultunboxer/vaultunboxer.go
+++ b/internal/executor/vaultunboxer/vaultunboxer.go
@@ -3,8 +3,10 @@ package vaultunboxer
 import (
 	"context"
 	"fmt"
+	"github.com/certifi/gocertifi"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/environment"
 	vault "github.com/hashicorp/vault/api"
+	"net/http"
 )
 
 const (
@@ -24,7 +26,13 @@ func New(client *vault.Client) *VaultUnboxer {
 }
 
 func NewFromEnvironment(ctx context.Context, env *environment.Environment) (*VaultUnboxer, error) {
-	client, err := vault.NewClient(vault.DefaultConfig())
+	config := vault.DefaultConfig()
+
+	tlsConfig := config.HttpClient.Transport.(*http.Transport).TLSClientConfig
+	pool, _ := gocertifi.CACerts()
+	tlsConfig.RootCAs = pool
+
+	client, err := vault.NewClient(config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A more proper way would be to use `config.ConfigureTLS()`, however, its input doesn't have a `CACertPool` field, yet we get the `*x509.CertPool` from `github.com/certifi/gocertifi` and [there's no way around that](https://github.com/certifi/gocertifi/pull/22), nor there's a way to turn `*x509.CertPool` into a string of certificate chains.