### PR TITLE
Increase timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD . /tmp/cirrus-ci-agent/
 RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 RUN apt-get update
 RUN apt-get -y install goreleaser
-RUN goreleaser build --single-target --snapshot
+RUN goreleaser build --single-target --snapshot --timeout 60m
 
 FROM alpine:latest
 


### PR DESCRIPTION
Cloud Build machines are too slow for multi-arch builds. Let's increase the timeout from the default 30 minutes.