### PR TITLE
Bump github.com/cirruslabs/cirrus-ci-annotations to 0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
-	github.com/cirruslabs/cirrus-ci-annotations v0.8.1
+	github.com/cirruslabs/cirrus-ci-annotations v0.9.0
 	github.com/cirruslabs/terminal v0.11.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-git/go-git/v5 v5.4.3-0.20220108132248-a5bbcd278ab1

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/cirruslabs/cirrus-ci-agent v1.51.0/go.mod h1:lEH1v2tn22T359W3fGjiAcYAY6jsqz75eHc4teh2nCY=
 github.com/cirruslabs/cirrus-ci-annotations v0.3.0/go.mod h1:xrmxzL58Pf4cSSQCmQEOPGQ3poeARxJdHneurUrqjZk=
-github.com/cirruslabs/cirrus-ci-annotations v0.8.1 h1:wwjFgPGT4Fi++MoRbskwfsEMsvp8dmVGYLBXRe5TChM=
-github.com/cirruslabs/cirrus-ci-annotations v0.8.1/go.mod h1:7gM9Z6+wnbcz6qLdBEVkSRL0pudxXGcNjVYWPwbEI2w=
+github.com/cirruslabs/cirrus-ci-annotations v0.9.0 h1:emR20kRolUI08JRFUqqenYwxgXbNlbfhuOEBAQHOktE=
+github.com/cirruslabs/cirrus-ci-annotations v0.9.0/go.mod h1:7gM9Z6+wnbcz6qLdBEVkSRL0pudxXGcNjVYWPwbEI2w=
 github.com/cirruslabs/terminal v0.2.5/go.mod h1:ubLe9fvd4FYeQV08ob5TNp9tsAfE0efkFtPrlKAwIKw=
 github.com/cirruslabs/terminal v0.11.0 h1:iWnyoogTA9BreM7kL0iGaZuQ6ASH0eC45Vz1QEm3FoE=
 github.com/cirruslabs/terminal v0.11.0/go.mod h1:5nVkiTg4y2ugDJjchuc9Lyz1cxu+KugFiJyuiESaYiY=


### PR DESCRIPTION
To include https://github.com/cirruslabs/cirrus-ci-annotations/pull/42.