### PR TITLE
Support artifacts upload over HTTPS: integration test fixes

### DIFF
--- a/internal/executor/artifacts.go
+++ b/internal/executor/artifacts.go
@@ -34,6 +34,7 @@ func (executor *Executor) UploadArtifacts(
 
 	artifacts, err := NewArtifacts(name, artifactsInstruction, customEnv)
 	if err != nil {
+		fmt.Fprintf(logUploader, "Failed to upload artifacts: %v", err)
 		return false
 	}
 

--- a/internal/executor/artifacts.go
+++ b/internal/executor/artifacts.go
@@ -35,6 +35,7 @@ func (executor *Executor) UploadArtifacts(
 	artifacts, err := NewArtifacts(name, artifactsInstruction, customEnv)
 	if err != nil {
 		fmt.Fprintf(logUploader, "Failed to upload artifacts: %v", err)
+
 		return false
 	}
 

--- a/internal/executor/artifacts.go
+++ b/internal/executor/artifacts.go
@@ -136,18 +136,19 @@ func uploadArtifacts(
 
 		for _, artifactPath := range pattern.Paths {
 			if artifactPath.info.IsDir() {
-				fmt.Fprintf(logUploader, "Skipping uploading of '%s' because it's a folder\n", artifactPath)
+				fmt.Fprintf(logUploader, "Skipping uploading of '%s' because it's a folder\n",
+					artifactPath.absolutePath)
 				continue
 			}
 
 			if artifactPath.info.Size() > 100*humanize.MByte {
-				fmt.Fprintf(logUploader, "Uploading a quite hefty artifact '%s' of size %s\n", artifactPath,
-					humanize.Bytes(uint64(artifactPath.info.Size())))
+				fmt.Fprintf(logUploader, "Uploading a quite hefty artifact '%s' of size %s\n",
+					artifactPath.absolutePath, humanize.Bytes(uint64(artifactPath.info.Size())))
 			}
 
 			artifactFile, err := os.Open(artifactPath.absolutePath)
 			if err != nil {
-				return errors.Wrapf(err, "failed to read artifact file %s", artifactPath)
+				return errors.Wrapf(err, "failed to read artifact file %s", artifactPath.absolutePath)
 			}
 
 			err = artifactUploader.Upload(ctx, artifactFile, artifactPath.relativePath)
@@ -158,7 +159,7 @@ func uploadArtifacts(
 
 			_ = artifactFile.Close()
 
-			fmt.Fprintf(logUploader, "Uploaded %s\n", artifactPath)
+			fmt.Fprintf(logUploader, "Uploaded %s\n", artifactPath.absolutePath)
 		}
 	}
 

--- a/internal/executor/artifacts_https.go
+++ b/internal/executor/artifacts_https.go
@@ -93,18 +93,12 @@ func (uploader *HTTPSUploader) Upload(
 }
 
 func (uploader *HTTPSUploader) Finish(ctx context.Context) error {
-	paths := uploader.artifacts.UploadableRelativePaths()
-
-	if len(paths) == 0 {
-		return nil
-	}
-
 	_, err := client.CirrusClient.CommitUploadedArtifacts(ctx, &api.CommitUploadedArtifactsRequest{
 		TaskIdentification: uploader.taskIdentification,
 		Name:               uploader.artifacts.Name,
 		Type:               uploader.artifacts.Type,
 		Format:             uploader.artifacts.Format,
-		Paths:              paths,
+		Paths:              uploader.artifacts.UploadableRelativePaths(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
In https://github.com/cirruslabs/cirrus-ci-agent/pull/263, at some point I've done a `git reset --hard` and was using a `master` agent for tests 🤦

This fixes the issues encountered and the integration tests should now pass.