### PR TITLE
uploadArtifactsWithRetries: don't overwrite err

### DIFF
--- a/internal/executor/utils.go
+++ b/internal/executor/utils.go
@@ -1,12 +1,12 @@
 package executor
 
 import (
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-ci-annotations/model"
 	"log"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"

--- a/internal/targz/targz.go
+++ b/internal/targz/targz.go
@@ -124,7 +124,7 @@ func untarFile(tr *tar.Reader, header *tar.Header, destination string, buffer []
 	switch header.Typeflag {
 	case tar.TypeDir:
 		return mkdir(filepath.Join(destination, header.Name))
-	case tar.TypeReg, tar.TypeRegA, tar.TypeChar, tar.TypeBlock, tar.TypeFifo:
+	case tar.TypeReg, tar.TypeChar, tar.TypeBlock, tar.TypeFifo:
 		return writeNewFile(filepath.Join(destination, header.Name), tr, header.FileInfo(), buffer)
 	case tar.TypeSymlink:
 		return writeNewSymbolicLink(filepath.Join(destination, header.Name), header.Linkname)


### PR DESCRIPTION
Also re-instantiate the uploader each try to avoid sending duplicate files.

The artifact-specific integration tests seem to pass just fine.

See https://github.com/cirruslabs/cirrus-ci-docs/issues/1146.