### PR TITLE
Push to GitHub Registry

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,7 +63,7 @@ task:
     - go test ./...
 
 task:
-  name: Release (Dry Run)
+  name: Release Binaries (Dry Run)
   only_if: $CIRRUS_TAG == ''
   depends_on:
     - test-linux
@@ -76,6 +76,20 @@ task:
   release_script: goreleaser build --snapshot
   binaries_artifacts:
     path: "dist/agent_*/agent*"
+
+docker_builder:
+  name: Release Docker Image (Dry Run)
+  only_if: $CIRRUS_TAG == ''
+  depends_on:
+    - test-linux
+    - test-windows
+    - test-macos
+    - test-freebsd
+  setup_script:
+    - docker buildx create --name multibuilder
+    - docker buildx use multibuilder
+    - docker buildx inspect --bootstrap
+  build_script: docker buildx build --platform linux/amd64,linux/arm64 --tag ghcr.io/cirruslabs/cirrus-ci-agent:latest .
 
 task:
   name: Release Binaries

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,7 +78,7 @@ task:
     path: "dist/agent_*/agent*"
 
 task:
-  name: Release
+  name: Release Binaries
   only_if: $CIRRUS_TAG != ''
   depends_on:
     - test-linux
@@ -98,3 +98,19 @@ task:
     - sentry-cli releases new $SENTRY_RELEASE
     - sentry-cli releases set-commits $SENTRY_RELEASE --auto
     - sentry-cli releases finalize $SENTRY_RELEASE
+
+docker_builder:
+  name: Release Docker Image
+  only_if: $CIRRUS_TAG != ''
+  depends_on:
+    - test-linux
+    - test-windows
+    - test-macos
+  env:
+    GITHUB_TOKEN: ENCRYPTED[!82ed873afdf627284305afef4958c85a8f73127b09978a9786ac521559630ea6c9a5ab6e7f8315abf9ead09b6eff6eae!]
+  login_script: echo $GITHUB_TOKEN | docker login ghcr.io -u fkorotkov --password-stdin
+  setup_script:
+    - docker buildx create --name multibuilder
+    - docker buildx use multibuilder
+    - docker buildx inspect --bootstrap
+  deploy_script: docker buildx build --push --platform linux/amd64,linux/arm64 --tag ghcr.io/cirruslabs/cirrus-ci-agent:$CIRRUS_TAG --tag ghcr.io/cirruslabs/cirrus-ci-agent:latest .

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,7 @@ RUN goreleaser build --single-target --snapshot --timeout 60m
 
 FROM alpine:latest
 
+LABEL org.opencontainers.image.source=https://github.com/cirruslabs/cirrus-ci-agent
+
 RUN apk add --no-cache rsync
 COPY --from=builder /tmp/cirrus-ci-agent/dist/agent_linux_*/agent /bin/cirrus-ci-agent

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['run', '--privileged', 'linuxkit/binfmt:v0.8']
+    args: ['run', '--privileged', '--rm', 'tonistiigi/binfmt', '--install', 'all']
     id: 'initialize-qemu'
   - name: 'gcr.io/cloud-builders/docker'
     args: ['buildx', 'create', '--name', 'mybuilder']


### PR DESCRIPTION
GCP's Cloud Build seems having some weird issues when it can't build multiarch images with error like this:

```
runtime: copying /usr/local/go/src/runtime/tls_arm64.h to /tmp/go-buildXXX/tls_GOARCH.h: write /tmp/go-buildXXX/tls_GOARCH.h: copy_file_range: function not implemented
```

Let's also build the image using our Docker Builder and push it to the GitHub registry.