### PR TITLE
Build just single binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM goreleaser/goreleaser:latest as builder
 WORKDIR /tmp/cirrus-ci-agent
 ADD . /tmp/cirrus-ci-agent/
 
-RUN goreleaser build --single-target --snapshot --timeout 60m
+RUN goreleaser build --id=agent --single-target --snapshot --timeout 60m
 
 FROM alpine:latest
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,4 +18,4 @@ options:
   env:
     # to use buildx for multiarch build via buildx
     - 'DOCKER_CLI_EXPERIMENTAL=enabled'
-timeout: 3600s
+timeout: 4800s


### PR DESCRIPTION
No need to attempt building `agent_cgo`