### PR TITLE
Retry clones on "timed out"

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -793,6 +793,9 @@ func retryableCloneError(err error) bool {
 	if strings.Contains(errorMessage, "timeout") {
 		return true
 	}
+	if strings.Contains(errorMessage, "timed out") {
+		return true
+	}
 	if strings.Contains(errorMessage, "tls") {
 		return true
 	}


### PR DESCRIPTION
It seems we were only checking error message for "timeout" and forgot "timed out".