### PR TITLE
Make os.Chdir(workingDir) error fatal

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -173,8 +173,13 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 	workingDir, ok := executor.env.Lookup("CIRRUS_WORKING_DIR")
 	if ok {
 		EnsureFolderExists(workingDir)
+
 		if err := os.Chdir(workingDir); err != nil {
-			log.Printf("Failed to change current working directory to '%s': %v", workingDir, err)
+			message := fmt.Sprintf("Failed to change current working directory to '%s': %v", workingDir, err)
+			log.Println(message)
+			executor.reportError(message)
+
+			return
 		}
 	} else {
 		log.Printf("Not changing current working directory because CIRRUS_WORKING_DIR is not set")


### PR DESCRIPTION
This allows for earlier error detection, since it's very unlikely that any command will ever run after `os.Chdir()` fails, because do this for every command:

https://github.com/cirruslabs/cirrus-ci-agent/blob/6093bc7d29d70960aca57f9852a541b2e4c8ff4d/internal/executor/shell.go#L149

See also https://github.com/cirruslabs/cirrus-cli/issues/620#issuecomment-1556779772.