### PR TITLE
Use x509.SetFallbackRoots and switch away from gocertifi

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ docker_builder:
     - apt-get update
     - apt-get install -y zsh
   install_golang_script:
-    - wget --no-verbose -O - https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xz
+    - wget --no-verbose -O - https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -C /usr/local -xz
   test_script:
     - export PATH=$PATH:/usr/local/go/bin
     - go test ./...

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"github.com/avast/retry-go"
+	"github.com/breml/rootcerts/embedded"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/client"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/executor"
@@ -63,6 +65,11 @@ func fullVersion() string {
 }
 
 func main() {
+	// Provide fallback root CA certificates
+	mozillaRoots := x509.NewCertPool()
+	mozillaRoots.AppendCertsFromPEM([]byte(embedded.MozillaCACertificatesPEM()))
+	x509.SetFallbackRoots(mozillaRoots)
+
 	apiEndpointPtr := flag.String("api-endpoint", "https://grpc.cirrus-ci.com:443", "GRPC endpoint URL")
 	taskIdPtr := flag.Int64("task-id", 0, "Task ID")
 	clientTokenPtr := flag.String("client-token", "", "Secret token")

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,16 @@
 module github.com/cirruslabs/cirrus-ci-agent
 
-go 1.18
+go 1.20
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
-	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d
+	github.com/breml/rootcerts v0.2.11
 	github.com/cirruslabs/cirrus-ci-annotations v0.9.0
 	github.com/cirruslabs/terminal v0.13.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/getsentry/sentry-go v0.18.0
 	github.com/go-git/go-git/v5 v5.6.0
-	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hashicorp/go-version v1.6.0
@@ -57,6 +56,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/breml/rootcerts v0.2.11 h1:njUAtoyZ6HUXPAPk63tGz0BEZk1/6gyfqK5fTzksHkM=
+github.com/breml/rootcerts v0.2.11/go.mod h1:S/PKh+4d1HUn4HQovEB8hPJZO6pUZYrIhmXBhsegfXw=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -154,8 +156,6 @@ github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
-github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d h1:S2NE3iHSwP0XV47EEXL8mWmRdEfGscSJ+7EgePNgt0s=
-github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/internal/executor/artifacts_https.go
+++ b/internal/executor/artifacts_https.go
@@ -2,9 +2,7 @@ package executor
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"github.com/certifi/gocertifi"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/client"
 	"github.com/samber/lo"
@@ -31,20 +29,6 @@ func NewHTTPSUploader(
 	taskIdentification *api.TaskIdentification,
 	artifacts *Artifacts,
 ) (ArtifactUploader, error) {
-	// Use Certifi's trust database since default system CA trust database
-	// in some container images like ubuntu:18.04 is outdated (without
-	// running apt-get update, etc.) and uploading an artifact results
-	// in"x509: certificate signed by unknown authority" error
-	certPool, _ := gocertifi.CACerts()
-
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: certPool,
-			},
-		},
-	}
-
 	// Create a mapping between relative artifact paths and upload URLs
 	uploadDescriptors := map[string]*UploadDescriptor{}
 
@@ -75,7 +59,7 @@ func NewHTTPSUploader(
 	}
 
 	return &HTTPSUploader{
-		httpClient:         httpClient,
+		httpClient:         &http.Client{},
 		taskIdentification: taskIdentification,
 		artifacts:          artifacts,
 		uploadDescriptors:  uploadDescriptors,

--- a/internal/executor/vaultunboxer/vaultunboxer.go
+++ b/internal/executor/vaultunboxer/vaultunboxer.go
@@ -3,9 +3,6 @@ package vaultunboxer
 import (
 	"context"
 	"fmt"
-	"net/http"
-
-	"github.com/certifi/gocertifi"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/environment"
 	vault "github.com/hashicorp/vault/api"
 )
@@ -36,10 +33,6 @@ func New(client *vault.Client) *VaultUnboxer {
 
 func NewFromEnvironment(ctx context.Context, env *environment.Environment) (*VaultUnboxer, error) {
 	config := vault.DefaultConfig()
-
-	tlsConfig := config.HttpClient.Transport.(*http.Transport).TLSClientConfig
-	pool, _ := gocertifi.CACerts()
-	tlsConfig.RootCAs = pool
 
 	client, err := vault.NewClient(config)
 	if err != nil {

--- a/internal/http_cache/http_cache.go
+++ b/internal/http_cache/http_cache.go
@@ -3,10 +3,8 @@ package http_cache
 import (
 	"bufio"
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/certifi/gocertifi"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/client"
 	"golang.org/x/sync/semaphore"
@@ -36,17 +34,13 @@ var httpProxyClient = &http.Client{}
 func Start(taskIdentification *api.TaskIdentification) string {
 	cirrusTaskIdentification = taskIdentification
 
-	certPool, err := gocertifi.CACerts()
-	if err == nil {
-		maxConcurrentConnections := runtime.NumCPU() * activeRequestsPerLogicalCPU
-		httpProxyClient = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig:     &tls.Config{RootCAs: certPool},
-				MaxIdleConns:        maxConcurrentConnections,
-				MaxIdleConnsPerHost: maxConcurrentConnections, // default is 2 which is too small
-			},
-			Timeout: 10 * time.Minute,
-		}
+	maxConcurrentConnections := runtime.NumCPU() * activeRequestsPerLogicalCPU
+	httpProxyClient = &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:        maxConcurrentConnections,
+			MaxIdleConnsPerHost: maxConcurrentConnections, // default is 2 which is too small
+		},
+		Timeout: 10 * time.Minute,
 	}
 
 	http.HandleFunc("/", handler)

--- a/pkg/grpchelper/grpchelper.go
+++ b/pkg/grpchelper/grpchelper.go
@@ -2,7 +2,6 @@ package grpchelper
 
 import (
 	"crypto/tls"
-	"github.com/certifi/gocertifi"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	insecurepkg "google.golang.org/grpc/credentials/insecure"
@@ -32,10 +31,8 @@ func TransportSettingsAsDialOption(apiEndpoint string) (string, grpc.DialOption)
 
 	// Use embedded root certificates because the agent can be executed in a distroless container
 	// and don't check for error, since then the default certificates from the host will be used
-	certPool, _ := gocertifi.CACerts()
 	tlsCredentials := credentials.NewTLS(&tls.Config{
 		MinVersion: tls.VersionTLS13,
-		RootCAs:    certPool,
 	})
 
 	return target, grpc.WithTransportCredentials(tlsCredentials)


### PR DESCRIPTION
Specific cases like https://github.com/cirruslabs/cirrus-ci-docs/issues/1150 should still work because even through the `ubuntu:18.04` is EOL, it ships without CA certificates (can be easily verified by running the container and [accessing these paths](https://github.com/golang/go/blob/34c0714bf27bdcc174d67e1243f6e8fd6bb802be/src/crypto/x509/root_linux.go)).

Similarly to https://github.com/cirruslabs/cirrus-cli/pull/628.