### PR TITLE
Clone instruction: report the actual HEAD

### DIFF
--- a/internal/executor/clone.go
+++ b/internal/executor/clone.go
@@ -226,6 +226,12 @@ func CloneRepository(
 		logUploader.Write([]byte("\nSucessfully updated submodules!"))
 	}
 
+	ref, err = repo.Head()
+	if err != nil {
+		logUploader.Write([]byte("\nFailed to get HEAD information!"))
+		return false
+	}
+
 	logUploader.Write([]byte(fmt.Sprintf("\nChecked out %s on %s branch.",
 		ref.Hash().String(), branch)))
 	logUploader.Write([]byte("\nSuccessfully cloned!"))


### PR DESCRIPTION
The change in https://github.com/cirruslabs/cirrus-ci-agent/pull/299 was reporting HEAD incorrectly because in cases like `SAME_SHA` we change the HEAD after a call to `repo.Head()`, so we need to call it again.