### PR TITLE
Relativize absolute symlinks only if they are within working directory

### DIFF
--- a/internal/targz/targz.go
+++ b/internal/targz/targz.go
@@ -52,7 +52,7 @@ func archiveSingleFolder(baseFolder string, folderPath string, tarWriter *tar.Wr
 
 		if header.Typeflag == tar.TypeSymlink {
 			linkDest, _ := os.Readlink(path)
-			if filepath.IsAbs(linkDest) {
+			if filepath.IsAbs(linkDest) && strings.HasPrefix(linkDest, baseFolder) {
 				linkDest, _ = filepath.Rel(baseFolder, linkDest)
 			}
 			header.Linkname = linkDest

--- a/internal/targz/targz_test.go
+++ b/internal/targz/targz_test.go
@@ -102,6 +102,12 @@ func TestArchive(t *testing.T) {
 			{tar.TypeDir, "", "", []byte{}},
 			{tar.TypeSymlink, "/symlink", ".", []byte{}},
 		}},
+		{"absolute links outside base are NOT made relative", func(dir string) {
+			os.Symlink("/tmp", filepath.Join(dir, "symlink"))
+		}, []PartialTarHeader{
+			{tar.TypeDir, "", "", []byte{}},
+			{tar.TypeSymlink, "/symlink", "/tmp", []byte{}},
+		}},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Reported to support that Python venv is creating a symplink to `/usr/bin/python3` which is not stored correctly.

As I remember the relativization was added since working directlory can change based on an instance. For example, persisten workers use a ramdom one in `/tmp` for each task. IMO it makes sense to only leave the tricky logic if a symlink is within base.