### PR TITLE
Make *.tar archiving cross-platform

### DIFF
--- a/internal/targz/targz_test.go
+++ b/internal/targz/targz_test.go
@@ -126,12 +126,6 @@ func TestArchive(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// Make paths OS-aware before comparing
-			for i := range testCase.Expected {
-				testCase.Expected[i].Name = filepath.FromSlash(testCase.Expected[i].Name)
-				testCase.Expected[i].Linkname = filepath.FromSlash(testCase.Expected[i].Linkname)
-			}
-
 			assert.Equal(t, testCase.Expected, TarGzContentsHelper(t, dest))
 		})
 	}

--- a/internal/targz/targz_test.go
+++ b/internal/targz/targz_test.go
@@ -152,8 +152,8 @@ func TestArchiveMultiple(t *testing.T) {
 	}
 
 	expected := []PartialTarHeader{
-		{tar.TypeDir, filepath.FromSlash("/left/hot"), "", []byte{}},
-		{tar.TypeDir, filepath.FromSlash("/right/cold"), "", []byte{}},
+		{tar.TypeDir, "/left/hot", "", []byte{}},
+		{tar.TypeDir, "/right/cold", "", []byte{}},
 	}
 	assert.Equal(t, expected, TarGzContentsHelper(t, dest))
 }


### PR DESCRIPTION
My normalizing all stored paths to slashes and denormilizing according to OS when unarchiving.