### PR TITLE
Introduce `CIRRUS_AGENT_EXPOSE_SCRIPTS_OUTPUTS`

### DIFF
--- a/internal/executor/shell.go
+++ b/internal/executor/shell.go
@@ -167,6 +167,14 @@ func NewShellCommands(
 	cmd.Stderr = sc.piper.FileProxy()
 	cmd.Stdout = sc.piper.FileProxy()
 
+	if custom_env != nil {
+	if custom_env != nil {
+		if _, ok := custom_env.Lookup("CIRRUS_AGENT_EXPOSE_SCRIPTS_OUTPUTS"); ok {
+			cmd.Stderr = io.MultiWriter(cmd.Stderr, sc.piper.FileProxy())
+			cmd.Stdout = io.MultiWriter(cmd.Stdout, sc.piper.FileProxy())
+		}
+	}
+
 	if err := sc.beforeStart(custom_env); err != nil {
 		return nil, err
 	}

--- a/internal/executor/shell.go
+++ b/internal/executor/shell.go
@@ -168,7 +168,6 @@ func NewShellCommands(
 	cmd.Stdout = sc.piper.FileProxy()
 
 	if custom_env != nil {
-	if custom_env != nil {
 		if _, ok := custom_env.Lookup("CIRRUS_AGENT_EXPOSE_SCRIPTS_OUTPUTS"); ok {
 			cmd.Stderr = io.MultiWriter(cmd.Stderr, sc.piper.FileProxy())
 			cmd.Stdout = io.MultiWriter(cmd.Stdout, sc.piper.FileProxy())

--- a/internal/executor/shell.go
+++ b/internal/executor/shell.go
@@ -169,8 +169,8 @@ func NewShellCommands(
 
 	if custom_env != nil {
 		if _, ok := custom_env.Lookup("CIRRUS_AGENT_EXPOSE_SCRIPTS_OUTPUTS"); ok {
-			cmd.Stderr = io.MultiWriter(cmd.Stderr, sc.piper.FileProxy())
-			cmd.Stdout = io.MultiWriter(cmd.Stdout, sc.piper.FileProxy())
+			cmd.Stderr = io.MultiWriter(os.Stderr, sc.piper.FileProxy())
+			cmd.Stdout = io.MultiWriter(os.Stdout, sc.piper.FileProxy())
 		}
 	}
 


### PR DESCRIPTION
In order to allow the agent to proxy all outputs of all scripts to the stdout/stderr. This is useful for folks having their own log collectors, for example, Stackdriver integration for GKE.

Made it opt-in since in this scenarios people pay for amount of logs collected, and we don't want to bring surprises to the bills.