### PR TITLE
Support passing task identification parameters via gRPC metadata

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -71,7 +71,7 @@ func main() {
 	x509.SetFallbackRoots(mozillaRoots)
 
 	apiEndpointPtr := flag.String("api-endpoint", "https://grpc.cirrus-ci.com:443", "GRPC endpoint URL")
-	taskIdPtr := flag.Int64("task-id", 0, "Task ID")
+	taskIdPtr := flag.String("task-id", "0", "Task ID")
 	clientTokenPtr := flag.String("client-token", "", "Secret token")
 	serverTokenPtr := flag.String("server-token", "", "Secret token")
 	versionFlag := flag.Bool("version", false, "display the version and exit")
@@ -99,6 +99,14 @@ func main() {
 	}
 	defer sentry.Flush(2 * time.Second)
 
+	// Parse task ID as an integer for backwards-compatibility with the TaskIdentification message
+	oldStyleTaskID, err := strconv.ParseInt(*taskIdPtr, 10, 64)
+	if err != nil {
+		log.Printf("Failed to parse task ID %q as an integer (%v), assuming that "+
+			"the new format of task IDs is in play", *taskIdPtr, err)
+		oldStyleTaskID = 0
+	}
+
 	// Enrich future events with Cirrus CI-specific tags
 	if tags, ok := os.LookupEnv("CIRRUS_SENTRY_TAGS"); ok {
 		sentry.ConfigureScope(func(scope *sentry.Scope) {
@@ -114,11 +122,11 @@ func main() {
 	}
 
 	// Initialize logger
-	logFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("cirrus-agent-%d.log", *taskIdPtr))
+	logFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("cirrus-agent-%s.log", *taskIdPtr))
 	if *stopHook {
 		// In case of a failure the log file will be persisted on the machine for debugging purposes.
 		// But unfortunately stop hook invocation will override it so let's use a different name.
-		logFilePath = filepath.Join(os.TempDir(), fmt.Sprintf("cirrus-agent-%d-hook.log", *taskIdPtr))
+		logFilePath = filepath.Join(os.TempDir(), fmt.Sprintf("cirrus-agent-%s-hook.log", *taskIdPtr))
 	}
 	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0660)
 	if err != nil {
@@ -133,7 +141,7 @@ func main() {
 			log.Printf("Finalizing log file, %d bytes written", logFilePos)
 
 			_ = logFile.Close()
-			uploadAgentLogs(context.Background(), logFilePath, *taskIdPtr, *clientTokenPtr)
+			uploadAgentLogs(context.Background(), logFilePath, oldStyleTaskID, *clientTokenPtr)
 		}()
 	}
 	multiWriter := io.MultiWriter(logFile, os.Stdout)
@@ -163,7 +171,7 @@ func main() {
 
 		request := &api.ReportAgentProblemRequest{
 			TaskIdentification: &api.TaskIdentification{
-				TaskId: *taskIdPtr,
+				TaskId: oldStyleTaskID,
 				Secret: *clientTokenPtr,
 			},
 			Message: fmt.Sprint(err),
@@ -210,7 +218,7 @@ func main() {
 
 			log.Printf("Captured %v...", sig)
 
-			reportSignal(context.Background(), sig, *taskIdPtr, *clientTokenPtr)
+			reportSignal(context.Background(), sig, oldStyleTaskID, *clientTokenPtr)
 		}
 	}()
 
@@ -237,7 +245,7 @@ func main() {
 	if *stopHook {
 		log.Printf("Stop hook!\n")
 		taskIdentification := api.TaskIdentification{
-			TaskId: *taskIdPtr,
+			TaskId: oldStyleTaskID,
 			Secret: *clientTokenPtr,
 		}
 		request := api.ReportStopHookRequest{
@@ -245,7 +253,7 @@ func main() {
 		}
 		_, err = client.CirrusClient.ReportStopHook(ctx, &request)
 		if err != nil {
-			log.Printf("Failed to report stop hook for task %d: %v\n", *taskIdPtr, err)
+			log.Printf("Failed to report stop hook for task %s: %v\n", *taskIdPtr, err)
 		} else {
 			logFile.Close()
 			os.Remove(logFilePath)
@@ -270,9 +278,9 @@ func main() {
 		}
 	}
 
-	go runHeartbeat(*taskIdPtr, *clientTokenPtr, conn)
+	go runHeartbeat(oldStyleTaskID, *clientTokenPtr, conn)
 
-	buildExecutor := executor.NewExecutor(*taskIdPtr, *clientTokenPtr, *serverTokenPtr, *commandFromPtr, *commandToPtr,
+	buildExecutor := executor.NewExecutor(oldStyleTaskID, *clientTokenPtr, *serverTokenPtr, *commandFromPtr, *commandToPtr,
 		*preCreatedWorkingDir)
 	buildExecutor.RunBuild(ctx)
 }

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/client"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
 	"testing"
 )
 
@@ -16,7 +17,7 @@ func Test_DialNoSchema(t *testing.T) {
 }
 
 func checkEndpoint(endpoint string) error {
-	clientConn, err := dialWithTimeout(context.Background(), endpoint)
+	clientConn, err := dialWithTimeout(context.Background(), endpoint, metadata.New(map[string]string{}))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
With this change, the authentication layer can be made more DRY and non-numeric task IDs will be supported.