### PR TITLE
Don't mess with piper

### DIFF
--- a/internal/executor/shell_unix_test.go
+++ b/internal/executor/shell_unix_test.go
@@ -14,6 +14,12 @@ import (
 	"time"
 )
 
+func TestCirrusAgentExposeScriptsOutputs(t *testing.T) {
+	success, _ := ShellCommandsAndGetOutput(context.Background(), []string{"echo test; sleep 1; echo test"},
+		environment.New(map[string]string{"CIRRUS_AGENT_EXPOSE_SCRIPTS_OUTPUTS": ""}))
+	assert.True(t, success)
+}
+
 func TestZshDoesNotHang(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
This fixes getting a `SIGPIPE` due to piper closure after the child process starts: https://github.com/cirruslabs/cirrus-ci-agent/blob/697ced3a26b6cd8f66a5eea5b0b8ccf9bfd93554/internal/executor/shell.go#L194-L198

No descriptor is inherited by the child process when using `io.MultiWriter`, so let's use it indirectly.