### PR TITLE
feat(vault): add support for arguments

### DIFF
--- a/internal/executor/vaultunboxer/vaultunboxer_test.go
+++ b/internal/executor/vaultunboxer/vaultunboxer_test.go
@@ -59,7 +59,14 @@ func TestVault(t *testing.T) {
 	selector, err := vaultunboxer.NewBoxedValue("VAULT[secret/data/keys data.admin]")
 	require.NoError(t, err)
 
+	selector_arg, err := vaultunboxer.NewBoxedValue("VAULT[secret/data/keys data.admin version=1]")
+	require.NoError(t, err)
+
 	secretValue, err := vaultunboxer.New(client).Unbox(ctx, selector)
+	require.NoError(t, err)
+	require.Equal(t, secretKeyValue, secretValue)
+
+	secretValue, err = vaultunboxer.New(client).Unbox(ctx, selector_arg)
 	require.NoError(t, err)
 	require.Equal(t, secretKeyValue, secretValue)
 }


### PR DESCRIPTION
This PR is adding support to set arguments for fetching credentials.


Some enabled use cases are the following:
- adjust the TTL of AWS credentials
  - https://developer.hashicorp.com/vault/api-docs/secret/aws#ttl
  - `VAULT[path/aws/sts/role-name access_key ttl=900]`
- select the secret version of a KV entry
  - https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#version
  - `VAULT[path/kv/data/entry data.foo version=2]`

To get a cached value, the arguments must be equal.