### PR TITLE
Better pipeline failure detection

### DIFF
--- a/internal/executor/cmd.go
+++ b/internal/executor/cmd.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cirruslabs/cirrus-ci-agent/internal/shellwords"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 )
 
@@ -41,9 +40,7 @@ func createCmd(scripts []string, customEnv *environment.Environment) (*exec.Cmd,
 	// add shebang
 	scriptFile.WriteString(fmt.Sprintf("#!%s\n", cmdShell))
 	scriptFile.WriteString("set -e\n")
-	if strings.Contains(cmdShell, "bash") {
-		scriptFile.WriteString("set -o pipefail\n")
-	}
+	scriptFile.WriteString("set -o pipefail 2>/dev/null || true\n")
 	scriptFile.WriteString("set -o verbose\n")
 	for i := 0; i < len(scripts); i++ {
 		scriptFile.WriteString(scripts[i])

--- a/internal/executor/shell_unix_test.go
+++ b/internal/executor/shell_unix_test.go
@@ -14,6 +14,15 @@ import (
 	"time"
 )
 
+func TestPipelineFailureDetection(t *testing.T) {
+	env := environment.New(map[string]string{
+		"CIRRUS_SHELL": "/bin/sh",
+	})
+
+	success, _ := ShellCommandsAndGetOutput(context.Background(), []string{"false | true"}, env)
+	assert.False(t, success)
+}
+
 func TestCirrusAgentExposeScriptsOutputs(t *testing.T) {
 	success, _ := ShellCommandsAndGetOutput(context.Background(), []string{"echo test; sleep 1; echo test"},
 		environment.New(map[string]string{"CIRRUS_AGENT_EXPOSE_SCRIPTS_OUTPUTS": ""}))


### PR DESCRIPTION
I've created the following script instruction to run on FreeBSD:

```yaml
install_golang_script:
  - wget --no-verbose -O - https://go.dev/dl/go1.21.5.freebsd-amd64.tar.gz | tar -C /usr/local -xz
```

And it was marked as succeed, but in reality, it failed because `wget` was not installed:

<img width="1147" alt="Screenshot 2023-12-18 at 17 18 56" src="https://github.com/cirruslabs/cirrus-ci-agent/assets/85709/5bc24790-bc3f-4f47-8ec0-94901b66633f">

This seems to be happening because the `pipefail` option is only set on when using Bash:

https://github.com/cirruslabs/cirrus-ci-agent/blob/445a87400c7f080f7bc7a142b76284d47ae61afe/internal/executor/cmd.go#L44-L46

It seems that we can try to enable the `pipefail` option opportunistically by utilizing the `||` (logical OR expression) to avoid failing the whole script if the option is not defined for a given shell.

Also, nowadays most shells seems to support `pipefail`, for example, on OpenBSD, the `/bin/sh` is actually `/bin/ksh`:

>This version of **sh** is actually **ksh** in disguise. As such, it also supports the features described in [`ksh(1)`](https://man.openbsd.org/ksh.1).

...and `ksh(1)` supports `pipefail`.

On FreeBSD, `/bin/sh` [supports `pipefail` option](https://man.freebsd.org/cgi/man.cgi?query=sh&apropos=0&sektion=0&manpath=FreeBSD+14.0-RELEASE+and+Ports&arch=default&format=html) natively.

ZSH seems to support `pipefail` too, at least on macOS:

```shell
% zsh -c 'set -o pipefail' ; echo $?
0

```