### PR TITLE
Use a separate pre-expanded environment for Vault-unboxing process

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,14 +21,14 @@ docker_builder:
   modules_cache:
     fingerprint_script: cat go.sum
     folder: $GOPATH/pkg/mod
-  install_zsh_script:
+  prepare_script:
     - apt-get update
     - apt-get install -y zsh
   install_golang_script:
-    - wget --no-verbose -O - https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -C /usr/local -xz
+    - wget --no-verbose -O - https://go.dev/dl/go1.21.5.linux-amd64.tar.gz | tar -C /usr/local -xz
   test_script:
     - export PATH=$PATH:/usr/local/go/bin
-    - go test ./...
+    - go test -v ./...
   env:
     HOME: /root
 
@@ -41,7 +41,7 @@ docker_builder:
     - choco install -y golang git
     - refreshenv
     - md C:\Windows\system32\config\systemprofile\AppData\Local\Temp
-    - go test ./...
+    - go test -v ./...
 
 task:
   name: Test (macOS)
@@ -51,16 +51,22 @@ task:
   test_script:
     - brew update
     - brew install go
-    - go test ./...
+    - go test -v ./...
 
 task:
   name: Test (FreeBSD)
   alias: test-freebsd
   freebsd_instance:
-    image_family: freebsd-12-2
+    image_family: freebsd-13-2
+  prepare_script:
+    - pkg install -y zsh git wget
+  install_golang_script:
+    - wget --no-verbose -O - https://go.dev/dl/go1.21.5.freebsd-amd64.tar.gz | tar -C /usr/local -xz
   test_script:
-    - pkg install -y zsh go git
-    - go test ./...
+    - export PATH=$PATH:/usr/local/go/bin
+    - go test -v ./...
+  env:
+    HOME: /root
 
 task:
   name: Release Binaries (Dry Run)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cirruslabs/cirrus-ci-agent
 
-go 1.20
+go 1.21
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1 h1:EKPd1INOIyr5hWOWhvpmQpY6tKjeG0hT1s3AMC/9fic=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1/go.mod h1:VzwV+t+dZ9j/H867F1M2ziD+yLHtB46oM35FxxMJ4d0=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -9,6 +10,7 @@ github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.10.0-rc.8 h1:YSZVvlIIDD1UxQpJp0h+dnpLUw+TrY0cx8obKsp3bek=
+github.com/Microsoft/hcsshim v0.10.0-rc.8/go.mod h1:OEthFdQv/AD2RAdzR6Mm1N1KPCztGKDurW1Z8b8VGMM=
 github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4/go.mod h1:UBYPn8k0D56RtnR8RFQMjmh4KrZzWJ5o7Z9SYjossQ8=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
@@ -23,6 +25,7 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
@@ -87,6 +90,7 @@ github.com/getsentry/sentry-go v0.18.0/go.mod h1:Kgon4Mby+FJ7ZWHFUAZgVaIa8sxHtnR
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
@@ -106,6 +110,7 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
+github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -179,6 +184,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -193,6 +199,7 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
@@ -229,6 +236,7 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.m
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
+github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -243,6 +251,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
@@ -411,6 +420,7 @@ golang.org/x/term v0.0.0-20220722155259-a9ba230a4035/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -472,6 +482,7 @@ gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
+gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/internal/environment/expand.go
+++ b/internal/environment/expand.go
@@ -1,16 +1,15 @@
 package environment
 
 import (
+	"maps"
 	"os"
 	"regexp"
 	"strings"
 )
 
 func ExpandEnvironmentRecursively(environment map[string]string) map[string]string {
-	result := make(map[string]string)
-	for key, value := range environment {
-		result[key] = value
-	}
+	result := maps.Clone(environment)
+
 	for step := 0; step < 10; step++ {
 		var changed = false
 		for key, value := range result {

--- a/internal/executor/cmd.go
+++ b/internal/executor/cmd.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package executor
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package executor_test
 
 import (

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,11 +1,117 @@
 package executor_test
 
 import (
+	"context"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/client"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/executor"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/testutil"
+	"github.com/google/uuid"
+	vault "github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"testing"
 )
+
+// TestVaultSpecificVariableExpansion ensures that:
+//
+//  1. We expand most of the environment variables before Vault-boxed variable resolution.
+//
+//     This allows us to compose CIRRUS_VAULT_URL and VAULT[...] out of other variables
+//     (see CIRRUS_VAULT_URL and VAULT_BOXED_VALUE for examples).
+//
+//  2. We delay expanding the variables that point to Vault-boxed variables until all
+//     Vault-boxed variables are expanded.
+//
+//     This allows us to compose variables out of other Vault-boxed variables,
+//     (see VALUE_USING_VAULT_BOXED_VALUE for an example).
+func TestVaultSpecificVariableExpansion(t *testing.T) {
+	ctx := context.Background()
+
+	var vaultToken = uuid.New().String()
+
+	// Create and start the Vault container
+	request := testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        testutil.VaultContainerImage,
+			ExposedPorts: []string{"8200/tcp"},
+			Env: map[string]string{
+				"VAULT_DEV_ROOT_TOKEN_ID": vaultToken,
+			},
+		},
+		Started: true,
+	}
+	container, err := testcontainers.GenericContainer(ctx, request)
+	require.NoError(t, err)
+	defer container.Terminate(ctx)
+
+	// Create demo data
+	vaultURL, err := container.Endpoint(ctx, "http")
+	require.NoError(t, err)
+
+	vaultClient, err := vault.NewClient(vault.DefaultConfig())
+	require.NoError(t, err)
+
+	require.NoError(t, vaultClient.SetAddress(vaultURL))
+	vaultClient.SetToken(vaultToken)
+
+	_, err = vaultClient.KVv2("secret").Put(ctx, "account", map[string]interface{}{
+		"password": "not really a secret",
+	})
+	require.NoError(t, err)
+
+	// Initialize Cirrus CI service mock
+	cirrusCIServiceMock := testutil.NewCirrusCIServiceMock(t,
+		&api.CommandsResponse{
+			TimeoutInSeconds: 60,
+			Environment: map[string]string{
+				"INDIRECT_VAULT_URL":                   vaultURL,
+				"CIRRUS_VAULT_URL":                     "${INDIRECT_VAULT_URL}",
+				"CIRRUS_VAULT_TOKEN":                   vaultToken,
+				"PASSWORD_KEY":                         "password",
+				"INDIRECT_VAULT_BOXED_VALUE":           "VAULT[secret/data/account data.$PASSWORD_KEY]",
+				"VAULT_BOXED_VALUE":                    "${INDIRECT_VAULT_BOXED_VALUE}",
+				"VALUE_USING_VAULT_BOXED_VALUE":        "${VAULT_BOXED_VALUE}",
+				"VALUE_USING_VAULT_BOXED_VALUE_PREFIX": "prefix-${VAULT_BOXED_VALUE}",
+				"VALUE_USING_VAULT_BOXED_VALUE_SUFFIX": "${VAULT_BOXED_VALUE}-suffix",
+				"VALUE_USING_VAULT_BOXED_VALUE_BOTH":   "prefix-${VAULT_BOXED_VALUE}-suffix",
+			},
+			Commands: []*api.Command{
+				{
+					Name: "test",
+					Instruction: &api.Command_ScriptInstruction{
+						ScriptInstruction: &api.ScriptInstruction{
+							Scripts: []string{
+								"test \"$VALUE_USING_VAULT_BOXED_VALUE\" = \"not really a secret\"",
+								"test \"$VALUE_USING_VAULT_BOXED_VALUE_PREFIX\" = \"prefix-not really a secret\"",
+								"test \"$VALUE_USING_VAULT_BOXED_VALUE_SUFFIX\" = \"not really a secret-suffix\"",
+								"test \"$VALUE_USING_VAULT_BOXED_VALUE_BOTH\" = \"prefix-not really a secret-suffix\"",
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	// Initialize Cirrus CI service client
+	conn, err := grpc.Dial(cirrusCIServiceMock.Address(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	client.InitClient(conn)
+
+	// Run the executor
+	executor := executor.NewExecutor(0, "", "", "", "",
+		t.TempDir())
+	executor.RunBuild(context.Background())
+
+	// Make sure that the commands succeeded
+	require.True(t, cirrusCIServiceMock.Finished(), "task has not finished")
+	require.True(t, cirrusCIServiceMock.Succeeded(), "task has not succeeded")
+}
 
 func TestLimitCommands(t *testing.T) {
 	commands := []*api.Command{

--- a/internal/executor/metrics/source/cgroup/cpu/cpu_unsupported.go
+++ b/internal/executor/metrics/source/cgroup/cpu/cpu_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package cpu
 

--- a/internal/executor/metrics/source/cgroup/cpu/v1.go
+++ b/internal/executor/metrics/source/cgroup/cpu/v1.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cpu
 

--- a/internal/executor/metrics/source/cgroup/cpu/v2.go
+++ b/internal/executor/metrics/source/cgroup/cpu/v2.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package cpu
 

--- a/internal/executor/metrics/source/cgroup/memory/memory_unsupported.go
+++ b/internal/executor/metrics/source/cgroup/memory/memory_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package memory
 

--- a/internal/executor/metrics/source/cgroup/memory/v1.go
+++ b/internal/executor/metrics/source/cgroup/memory/v1.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package memory
 

--- a/internal/executor/metrics/source/cgroup/memory/v2.go
+++ b/internal/executor/metrics/source/cgroup/memory/v2.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package memory
 

--- a/internal/executor/metrics/source/cgroup/resolver/resolver_unsupported.go
+++ b/internal/executor/metrics/source/cgroup/resolver/resolver_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package resolver
 

--- a/internal/executor/shell_linux_test.go
+++ b/internal/executor/shell_linux_test.go
@@ -1,5 +1,4 @@
 //go:build !windows || !freebsd
-// +build !windows !freebsd
 
 package executor
 

--- a/internal/executor/shell_unix_test.go
+++ b/internal/executor/shell_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package executor
 

--- a/internal/executor/shell_windows_test.go
+++ b/internal/executor/shell_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package executor
 

--- a/internal/executor/shellcommands.go
+++ b/internal/executor/shellcommands.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package executor
 

--- a/internal/executor/vaultunboxer/vaultunboxer.go
+++ b/internal/executor/vaultunboxer/vaultunboxer.go
@@ -53,7 +53,9 @@ func NewFromEnvironment(ctx context.Context, env *environment.Environment) (*Vau
 		client.SetNamespace(namespace)
 	}
 
-	if jwtToken, ok := env.Lookup("CIRRUS_OIDC_TOKEN"); ok {
+	if vaultToken, ok := env.Lookup("CIRRUS_VAULT_TOKEN"); ok {
+		client.SetToken(vaultToken)
+	} else if jwtToken, ok := env.Lookup("CIRRUS_OIDC_TOKEN"); ok {
 		auth := &JWTAuth{
 			Token: jwtToken,
 			Role:  env.Get(EnvCirrusVaultRole),

--- a/internal/executor/vaultunboxer/vaultunboxer_test.go
+++ b/internal/executor/vaultunboxer/vaultunboxer_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package vaultunboxer_test
 

--- a/internal/executor/vaultunboxer/vaultunboxer_test.go
+++ b/internal/executor/vaultunboxer/vaultunboxer_test.go
@@ -6,6 +6,7 @@ package vaultunboxer_test
 import (
 	"context"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/executor/vaultunboxer"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/testutil"
 	"github.com/google/uuid"
 	vault "github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/require"
@@ -13,8 +14,6 @@ import (
 	"testing"
 	"time"
 )
-
-const vaultContainerImage = "hashicorp/vault:latest"
 
 func TestVault(t *testing.T) {
 	ctx := context.Background()
@@ -24,7 +23,7 @@ func TestVault(t *testing.T) {
 	// Create and start the HashiCorp's Vault container
 	request := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        vaultContainerImage,
+			Image:        testutil.VaultContainerImage,
 			ExposedPorts: []string{"8200/tcp"},
 			Env: map[string]string{
 				"VAULT_DEV_ROOT_TOKEN_ID": vaultToken,
@@ -79,7 +78,7 @@ func TestVaultUseCache(t *testing.T) {
 	// Create and start the HashiCorp's Vault container
 	request := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        vaultContainerImage,
+			Image:        testutil.VaultContainerImage,
 			ExposedPorts: []string{"8200/tcp"},
 			Env: map[string]string{
 				"VAULT_DEV_ROOT_TOKEN_ID": vaultToken,
@@ -160,7 +159,7 @@ func TestVaultDictionaryAsJSON(t *testing.T) {
 	// Create and start the HashiCorp's Vault container
 	request := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        vaultContainerImage,
+			Image:        testutil.VaultContainerImage,
 			ExposedPorts: []string{"8200/tcp"},
 			Env: map[string]string{
 				"VAULT_DEV_ROOT_TOKEN_ID": vaultToken,

--- a/internal/signalfilter/signalfilter.go
+++ b/internal/signalfilter/signalfilter.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package signalfilter
 

--- a/internal/testutil/constants.go
+++ b/internal/testutil/constants.go
@@ -1,0 +1,3 @@
+package testutil
+
+const VaultContainerImage = "hashicorp/vault:latest"

--- a/internal/testutil/rpc.go
+++ b/internal/testutil/rpc.go
@@ -1,0 +1,99 @@
+package testutil
+
+import (
+	"context"
+	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+type CirrusCIServiceMock struct {
+	// Initialization state
+	lis              net.Listener
+	commandsResponse *api.CommandsResponse
+
+	// Running state
+	finished  atomic.Bool
+	succeeded atomic.Bool
+
+	api.UnimplementedCirrusCIServiceServer
+}
+
+func NewCirrusCIServiceMock(t *testing.T, commandsResponse *api.CommandsResponse) *CirrusCIServiceMock {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+
+	m := &CirrusCIServiceMock{
+		lis:              lis,
+		commandsResponse: commandsResponse,
+	}
+
+	server := grpc.NewServer()
+	api.RegisterCirrusCIServiceServer(server, m)
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			panic(err)
+		}
+	}()
+
+	return m
+}
+
+func (m *CirrusCIServiceMock) Address() string {
+	return m.lis.Addr().String()
+}
+
+func (m *CirrusCIServiceMock) Finished() bool {
+	return m.finished.Load()
+}
+
+func (m *CirrusCIServiceMock) Succeeded() bool {
+	return m.succeeded.Load()
+}
+
+func (m *CirrusCIServiceMock) InitialCommands(ctx context.Context, request *api.InitialCommandsRequest) (*api.CommandsResponse, error) {
+	return m.commandsResponse, nil
+}
+
+func (m *CirrusCIServiceMock) ReportCommandUpdates(ctx context.Context, request *api.ReportCommandUpdatesRequest) (*api.ReportCommandUpdatesResponse, error) {
+	return &api.ReportCommandUpdatesResponse{}, nil
+}
+
+func (m *CirrusCIServiceMock) StreamLogs(server api.CirrusCIService_StreamLogsServer) error {
+	for {
+		_, err := server.Recv()
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (m *CirrusCIServiceMock) SaveLogs(server api.CirrusCIService_SaveLogsServer) error {
+	for {
+		_, err := server.Recv()
+		if err != nil {
+			return err
+		}
+	}
+
+}
+
+func (m *CirrusCIServiceMock) ReportAgentFinished(ctx context.Context, request *api.ReportAgentFinishedRequest) (*api.ReportAgentFinishedResponse, error) {
+	m.finished.Store(true)
+
+	commandNameToStatus := lo.Associate(request.CommandResults, func(commandResult *api.CommandResult) (string, api.Status) {
+		return commandResult.Name, commandResult.Status
+	})
+	succeeded := lo.EveryBy(lo.Values(commandNameToStatus), func(status api.Status) bool {
+		return status == api.Status_COMPLETED || status == api.Status_SKIPPED
+	})
+	m.succeeded.Store(succeeded)
+
+	return &api.ReportAgentFinishedResponse{}, nil
+}


### PR DESCRIPTION
This achieves the same thing as https://github.com/cirruslabs/cirrus-ci-agent/pull/330, but without delaying the environment variable expansion step that might resolve the variables critical for the Vault client initialization (e.g. `CIRRUS_VAULT_URL`).

Will mark as ready to review once I'll come up with an appropriate test for this.