### PR TITLE
Run `always` instructions on timeout

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -289,7 +289,7 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 
 		var stepCtx context.Context
 
-		if command.ExecutionBehaviour == api.Command_ON_TIMEOUT {
+		if command.ExecutionBehaviour == api.Command_ON_TIMEOUT || command.ExecutionBehaviour == api.Command_ALWAYS {
 			stepCtx = extendedTimeoutCtx
 		} else {
 			stepCtx = timeoutCtx


### PR DESCRIPTION
Make sure in case of a timeout we run instructions marked as `always` via passing a context with an extended timeout.