### PR TITLE
HTTP cache: implement GitHub Actions cache endpoints

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ docker_builder:
     - apt-get update
     - apt-get install -y zsh
   install_golang_script:
-    - wget --no-verbose -O - https://go.dev/dl/go1.21.5.linux-amd64.tar.gz | tar -C /usr/local -xz
+    - wget --no-verbose -O - https://go.dev/dl/go1.22.1.linux-amd64.tar.gz | tar -C /usr/local -xz
   test_script:
     - export PATH=$PATH:/usr/local/go/bin
     - go test -v ./...
@@ -61,7 +61,7 @@ task:
   prepare_script:
     - pkg install -y zsh git wget
   install_golang_script:
-    - wget --no-verbose -O - https://go.dev/dl/go1.21.5.freebsd-amd64.tar.gz | tar -C /usr/local -xz
+    - wget --no-verbose -O - https://go.dev/dl/go1.22.1.freebsd-amd64.tar.gz | tar -C /usr/local -xz
   test_script:
     - export PATH=$PATH:/usr/local/go/bin
     - go test -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM goreleaser/goreleaser:latest as builder
+FROM golang:latest as builder
 
 WORKDIR /tmp/cirrus-ci-agent
 ADD . /tmp/cirrus-ci-agent/
+
+# Install GoReleaser
+RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
+RUN apt update && apt -y install goreleaser
 
 RUN goreleaser build --id=agent --single-target --snapshot --timeout 60m
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,10 @@ require (
 	github.com/cirruslabs/terminal v0.16.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/getsentry/sentry-go v0.26.0
+	github.com/go-chi/chi/v5 v5.0.12
+	github.com/go-chi/render v1.0.3
 	github.com/go-git/go-git/v5 v5.11.0
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/hashicorp/go-version v1.6.0
@@ -24,6 +27,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	github.com/testcontainers/testcontainers-go v0.23.0
+	github.com/tonistiigi/go-actions-cache v0.0.0-20240227172821-a0b64f338598
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
 	golang.org/x/net v0.20.0
 	golang.org/x/sync v0.6.0
@@ -39,6 +43,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
+	github.com/ajg/form v1.5.1 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
@@ -48,6 +53,7 @@ require (
 	github.com/creack/pty v1.1.21 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v24.0.7+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
@@ -59,6 +65,7 @@ require (
 	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -89,6 +96,7 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
+	github.com/puzpuzpuz/xsync/v3 v3.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cirruslabs/cirrus-ci-agent
 
-go 1.21
+go 1.22
 
 require (
 	github.com/avast/retry-go/v4 v4.5.1
@@ -10,7 +10,6 @@ require (
 	github.com/cirruslabs/terminal v0.16.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/getsentry/sentry-go v0.26.0
-	github.com/go-chi/chi/v5 v5.0.12
 	github.com/go-chi/render v1.0.3
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
@@ -22,6 +21,7 @@ require (
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/procfs v0.12.0
+	github.com/puzpuzpuz/xsync/v3 v3.1.0
 	github.com/samber/lo v1.39.0
 	github.com/shirou/gopsutil/v3 v3.24.1
 	github.com/sirupsen/logrus v1.9.3
@@ -96,7 +96,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
-	github.com/puzpuzpuz/xsync/v3 v3.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
+github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
+github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -52,6 +54,8 @@ github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
+github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v24.0.7+incompatible h1:Wo6l37AuwP3JaMnZa226lzVXGA3F9Ig1seQen0cKYlM=
@@ -77,6 +81,10 @@ github.com/getsentry/sentry-go v0.26.0 h1:IX3++sF6/4B5JcevhdZfdKIHfyvMmAq/UnqcyT
 github.com/getsentry/sentry-go v0.26.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
+github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
+github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
+github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
@@ -100,6 +108,10 @@ github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -219,6 +231,8 @@ github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b/go.mod h1:Om
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+github.com/puzpuzpuz/xsync/v3 v3.1.0 h1:EewKT7/LNac5SLiEblJeUu8z5eERHrmRLnMQL2d7qX4=
+github.com/puzpuzpuz/xsync/v3 v3.1.0/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
@@ -261,6 +275,8 @@ github.com/tklauser/go-sysconf v0.3.13/go.mod h1:zwleP4Q4OehZHGn4CYZDipCgg9usW5I
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/tklauser/numcpus v0.7.0 h1:yjuerZP127QG9m5Zh/mSO4wqurYil27tHrqwRoRjpr4=
 github.com/tklauser/numcpus v0.7.0/go.mod h1:bb6dMVcj8A42tSE7i32fsIUCbQNllK5iDguyOZRUzAY=
+github.com/tonistiigi/go-actions-cache v0.0.0-20240227172821-a0b64f338598 h1:DA/NDC0YbMdnfcOSUzAnbUZE6dSM54d+0hrBqG+bOfs=
+github.com/tonistiigi/go-actions-cache v0.0.0-20240227172821-a0b64f338598/go.mod h1:anhKd3mnC1shAbQj1Q4IJ+w6xqezxnyDYlx/yKa7IXM=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/getsentry/sentry-go v0.26.0 h1:IX3++sF6/4B5JcevhdZfdKIHfyvMmAq/UnqcyT
 github.com/getsentry/sentry-go v0.26.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
-github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
-github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
 github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=

--- a/internal/http_cache/ghacache/cirruscimock/cirruscimock.go
+++ b/internal/http_cache/ghacache/cirruscimock/cirruscimock.go
@@ -1,0 +1,91 @@
+package cirruscimock
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"io"
+	"net"
+	"testing"
+)
+
+type cirrusCIMock struct {
+	uploadedCacheEntries map[string]*bytes.Buffer
+
+	api.UnimplementedCirrusCIServiceServer
+}
+
+func ClientConn(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() {
+		server := grpc.NewServer()
+		api.RegisterCirrusCIServiceServer(server, &cirrusCIMock{
+			uploadedCacheEntries: map[string]*bytes.Buffer{},
+		})
+		require.NoError(t, server.Serve(lis))
+	}()
+
+	clientConn, err := grpc.DialContext(context.Background(), lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	return clientConn
+}
+
+func (mock *cirrusCIMock) UploadCache(stream api.CirrusCIService_UploadCacheServer) error {
+	var currentBuf *bytes.Buffer
+
+	for {
+		cacheEntry, err := stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return stream.SendAndClose(&api.UploadCacheResponse{})
+			}
+
+			return err
+		}
+
+		switch typed := cacheEntry.Value.(type) {
+		case *api.CacheEntry_Key:
+			currentBuf = &bytes.Buffer{}
+			mock.uploadedCacheEntries[typed.Key.CacheKey] = currentBuf
+		case *api.CacheEntry_Chunk:
+			currentBuf.Write(typed.Chunk.Data)
+		}
+	}
+}
+
+func (mock *cirrusCIMock) DownloadCache(request *api.DownloadCacheRequest, stream api.CirrusCIService_DownloadCacheServer) error {
+	buf, ok := mock.uploadedCacheEntries[request.CacheKey]
+	if !ok {
+		return status.Errorf(codes.NotFound, "cache entry for key %s is not found",
+			request.CacheKey)
+	}
+
+	return stream.Send(&api.DataChunk{Data: buf.Bytes()})
+}
+
+func (mock *cirrusCIMock) CacheInfo(ctx context.Context, request *api.CacheInfoRequest) (*api.CacheInfoResponse, error) {
+	buf, ok := mock.uploadedCacheEntries[request.CacheKey]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "cache entry for key %s is not found",
+			request.CacheKey)
+	}
+
+	return &api.CacheInfoResponse{
+		Info: &api.CacheInfo{
+			Key:         request.CacheKey,
+			SizeInBytes: int64(buf.Len()),
+		},
+	}, nil
+}

--- a/internal/http_cache/ghacache/ghacache.go
+++ b/internal/http_cache/ghacache/ghacache.go
@@ -1,0 +1,221 @@
+package ghacache
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/puzpuzpuz/xsync/v3"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const APIMountPoint = "/_apis/artifactcache"
+
+type GHACache struct {
+	cacheHost   string
+	mux         *chi.Mux
+	uploadables *xsync.MapOf[int64, *uploadable]
+}
+
+type uploadable struct {
+	Key     string
+	Version string
+	Buf     *bytes.Buffer
+}
+
+func New(cacheHost string) *GHACache {
+	cache := &GHACache{
+		cacheHost:   cacheHost,
+		mux:         chi.NewMux(),
+		uploadables: xsync.NewMapOf[int64, *uploadable](),
+	}
+
+	cache.mux.Get("/cache", cache.get)
+	cache.mux.Post("/caches", cache.reserveUploadable)
+	cache.mux.Patch("/caches/{id}", cache.updateUploadable)
+	cache.mux.Post("/caches/{id}", cache.commitUploadable)
+
+	return cache
+}
+
+func (cache *GHACache) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	cache.mux.ServeHTTP(writer, request)
+}
+
+func (cache *GHACache) get(writer http.ResponseWriter, request *http.Request) {
+	keys := strings.Split(request.URL.Query().Get("keys"), ",")
+	version := request.URL.Query().Get("version")
+
+	// The first key is used for exact matching which we support
+	httpCacheURL := cache.httpCacheURL(keys[0], version)
+
+	resp, err := http.Head(httpCacheURL)
+	if err != nil {
+		log.Printf("GHA cache failed to retrieve %q: %v\n", httpCacheURL, err)
+		writer.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		jsonResp := struct {
+			Key string `json:"cacheKey"`
+			URL string `json:"archiveLocation"`
+		}{
+			Key: keys[0],
+			URL: httpCacheURL,
+		}
+
+		render.JSON(writer, request, &jsonResp)
+
+		return
+	}
+
+	// The rest of the keys are used for prefix matching
+	// (fallback mechanism) which we do not support
+	if len(keys[1:]) != 0 {
+		log.Printf("GHA cache does not support prefix matching, was needed for (%v, %v)\n",
+			keys, version)
+		writer.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	writer.WriteHeader(http.StatusNoContent)
+}
+
+func (cache *GHACache) reserveUploadable(writer http.ResponseWriter, request *http.Request) {
+	var jsonReq struct {
+		Key     string `json:"key"`
+		Version string `json:"version"`
+	}
+
+	if err := render.DecodeJSON(request.Body, &jsonReq); err != nil {
+		log.Printf("GHA cache failed to read/decode the JSON passed to the "+
+			"reserve uploadable endpoint: %v\n", err)
+		writer.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	jsonResp := struct {
+		CacheID int64 `json:"cacheId"`
+	}{
+		CacheID: rand.Int63(),
+	}
+
+	cache.uploadables.Store(jsonResp.CacheID, &uploadable{
+		Key:     jsonReq.Key,
+		Version: jsonReq.Version,
+		Buf:     &bytes.Buffer{},
+	})
+
+	render.JSON(writer, request, &jsonResp)
+}
+
+func (cache *GHACache) updateUploadable(writer http.ResponseWriter, request *http.Request) {
+	id, ok := getID(request)
+	if !ok {
+		log.Printf("GHA cache failed to get/decode the ID passed to the " +
+			"update uploadable endpoint\n")
+		writer.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	uploadable, ok := cache.uploadables.Load(id)
+	if !ok {
+		writer.WriteHeader(http.StatusNotFound)
+
+		return
+	}
+
+	if _, err := io.Copy(uploadable.Buf, request.Body); err != nil {
+		if errors.Is(err, io.EOF) {
+			return
+		}
+
+		writer.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (cache *GHACache) commitUploadable(writer http.ResponseWriter, request *http.Request) {
+	id, ok := getID(request)
+	if !ok {
+		log.Printf("GHA cache failed to get/decode the ID passed to the " +
+			"commit uploadable endpoint\n")
+		writer.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	uploadable, ok := cache.uploadables.Load(id)
+	if !ok {
+		writer.WriteHeader(http.StatusNotFound)
+
+		return
+	}
+
+	var jsonReq struct {
+		Size int64 `json:"size"`
+	}
+
+	if err := render.DecodeJSON(request.Body, &jsonReq); err != nil {
+		log.Printf("GHA cache failed to read/decode the JSON passed to the "+
+			"commit uploadable endpoint: %v\n", err)
+		writer.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	if jsonReq.Size != int64(uploadable.Buf.Len()) {
+		log.Printf("GHA cache detected a cache entry size mismatch for uploadable "+
+			"with ID %d\n", id)
+		writer.WriteHeader(http.StatusBadRequest)
+
+		return
+	}
+
+	resp, err := http.Post(
+		cache.httpCacheURL(uploadable.Key, uploadable.Version),
+		"application/octet-stream",
+		bytes.NewReader(uploadable.Buf.Bytes()),
+	)
+	if err != nil {
+		log.Printf("GHA cache failed to upload the uploadable with ID %d: %v\n", id, err)
+		writer.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		log.Printf("GHA cache failed to upload the uploadable with ID %d: got HTTP %d\n",
+			id, resp.StatusCode)
+		writer.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	cache.uploadables.Delete(id)
+}
+
+func (cache *GHACache) httpCacheURL(key string, version string) string {
+	return fmt.Sprintf("http://%s/%s-%s", cache.cacheHost, key, version)
+}
+
+func getID(request *http.Request) (int64, bool) {
+	idRaw := chi.URLParam(request, "id")
+
+	id, err := strconv.ParseInt(idRaw, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return id, true
+}

--- a/internal/http_cache/ghacache/ghacache.go
+++ b/internal/http_cache/ghacache/ghacache.go
@@ -160,6 +160,7 @@ func (cache *GHACache) commitUploadable(writer http.ResponseWriter, request *htt
 
 		return
 	}
+	defer cache.uploadables.Delete(id)
 
 	var jsonReq struct {
 		Size int64 `json:"size"`
@@ -200,8 +201,6 @@ func (cache *GHACache) commitUploadable(writer http.ResponseWriter, request *htt
 
 		return
 	}
-
-	cache.uploadables.Delete(id)
 }
 
 func (cache *GHACache) httpCacheURL(key string, version string) string {

--- a/internal/http_cache/ghacache/ghacache.go
+++ b/internal/http_cache/ghacache/ghacache.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -204,7 +205,7 @@ func (cache *GHACache) commitUploadable(writer http.ResponseWriter, request *htt
 }
 
 func (cache *GHACache) httpCacheURL(key string, version string) string {
-	return fmt.Sprintf("http://%s/%s-%s", cache.cacheHost, key, version)
+	return fmt.Sprintf("http://%s/%s-%s", cache.cacheHost, url.PathEscape(key), url.PathEscape(version))
 }
 
 func getID(request *http.Request) (int64, bool) {

--- a/internal/http_cache/ghacache/ghacache_test.go
+++ b/internal/http_cache/ghacache/ghacache_test.go
@@ -1,0 +1,56 @@
+package ghacache_test
+
+import (
+	"bytes"
+	"context"
+	"github.com/cirruslabs/cirrus-ci-agent/api"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/client"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/http_cache"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/http_cache/ghacache/cirruscimock"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	actionscache "github.com/tonistiigi/go-actions-cache"
+	"testing"
+	"time"
+)
+
+func TestGHA(t *testing.T) {
+	ctx := context.Background()
+
+	client.InitClient(cirruscimock.ClientConn(t))
+
+	httpCacheURL := "http://" + http_cache.Start(&api.TaskIdentification{}) + "/"
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"ac":  `[]`,
+		"nbf": time.Now().Add(-time.Hour).Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	tokenString, err := token.SignedString([]byte("whatever"))
+	require.NoError(t, err)
+
+	ac, err := actionscache.New(tokenString, httpCacheURL, actionscache.Opt{})
+	require.NoError(t, err)
+
+	cacheKey := uuid.NewString()
+	cacheValue := []byte("Hello, World!\n")
+
+	// Ensure that an entry for our cache key is not present
+	entry, err := ac.Load(ctx, cacheKey)
+	require.NoError(t, err)
+	require.Nil(t, entry)
+
+	// Upload an entry for our cache key
+	require.NoError(t, ac.Save(ctx, cacheKey, actionscache.NewBlob(cacheValue)))
+
+	// Ensure that an entry for our cache key is present
+	// and matches to what we've previously put in the cache
+	entry, err = ac.Load(ctx, cacheKey)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	require.Equal(t, entry.Key, cacheKey)
+	buf := &bytes.Buffer{}
+	require.NoError(t, entry.WriteTo(ctx, buf))
+	require.Equal(t, cacheValue, buf.Bytes())
+}

--- a/internal/http_cache/http_cache.go
+++ b/internal/http_cache/http_cache.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"github.com/cirruslabs/cirrus-ci-agent/api"
 	"github.com/cirruslabs/cirrus-ci-agent/internal/client"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/http_cache/ghacache"
+	"github.com/go-chi/chi/v5"
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -43,7 +45,10 @@ func Start(taskIdentification *api.TaskIdentification) string {
 		Timeout: 10 * time.Minute,
 	}
 
-	http.HandleFunc("/", handler)
+	mux := chi.NewMux()
+
+	// HTTP cache protocol
+	mux.HandleFunc("/*", handler)
 
 	address := "127.0.0.1:12321"
 	listener, err := net.Listen("tcp", address)
@@ -55,7 +60,11 @@ func Start(taskIdentification *api.TaskIdentification) string {
 	if err == nil {
 		address = listener.Addr().String()
 		log.Printf("Starting http cache server %s\n", address)
-		go http.Serve(listener, nil)
+
+		// GitHub Actions cache API
+		mux.Mount(ghacache.APIMountPoint, ghacache.New(address))
+
+		go http.Serve(listener, mux)
 	} else {
 		log.Printf("Failed to start http cache server %s: %s\n", address, err)
 	}


### PR DESCRIPTION
How to run locally for testing purposes:

1. Generate a JWT token, see `TestGHA`
2. Create a dummy `Dockerfile`, e.g. with `FROM debian:latest` contents
3. `docker buildx build -t whatever --cache-to type=gha,url=http://<your IP reachable from Docker VM>:12321/,token=<token generated in step 1>,scope=image .`

Resolves https://github.com/cirruslabs/cirrus-ci-agent/issues/344.