### PR TITLE
GHA cache improvements

### DIFF
--- a/internal/http_cache/ghacache/ghacache.go
+++ b/internal/http_cache/ghacache/ghacache.go
@@ -145,6 +145,8 @@ func (cache *GHACache) updateUploadable(writer http.ResponseWriter, request *htt
 
 		return
 	}
+
+	writer.WriteHeader(http.StatusOK)
 }
 
 func (cache *GHACache) commitUploadable(writer http.ResponseWriter, request *http.Request) {
@@ -210,6 +212,8 @@ func (cache *GHACache) commitUploadable(writer http.ResponseWriter, request *htt
 
 		return
 	}
+
+	writer.WriteHeader(http.StatusCreated)
 }
 
 func (cache *GHACache) httpCacheURL(key string, version string) string {

--- a/internal/http_cache/ghacache/httprange/httprange.go
+++ b/internal/http_cache/ghacache/httprange/httprange.go
@@ -32,7 +32,6 @@ package httprange
 
 import (
 	"errors"
-	"fmt"
 	"net/textproto"
 	"strconv"
 	"strings"
@@ -45,17 +44,6 @@ var errNoOverlap = errors.New("invalid range: failed to overlap")
 // HTTPRange specifies the byte range to be sent to the client.
 type HTTPRange struct {
 	Start, Length int64
-}
-
-func (r HTTPRange) contentRange(size int64) string {
-	return fmt.Sprintf("bytes %d-%d/%d", r.Start, r.Start+r.Length-1, size)
-}
-
-func (r HTTPRange) mimeHeader(contentType string, size int64) textproto.MIMEHeader {
-	return textproto.MIMEHeader{
-		"Content-Range": {r.contentRange(size)},
-		"Content-Type":  {contentType},
-	}
 }
 
 // ParseRange parses a Range header string as per RFC 7233.

--- a/internal/http_cache/ghacache/httprange/httprange.go
+++ b/internal/http_cache/ghacache/httprange/httprange.go
@@ -1,0 +1,135 @@
+// parseRange() parsing function from Golang's source code tree (src/net/http/fs.go).
+//
+// Copyright 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package httprange
+
+import (
+	"errors"
+	"fmt"
+	"net/textproto"
+	"strconv"
+	"strings"
+)
+
+// errNoOverlap is returned by serveContent's parseRange if first-byte-pos of
+// all of the byte-range-spec values is greater than the content size.
+var errNoOverlap = errors.New("invalid range: failed to overlap")
+
+// httpRange specifies the byte range to be sent to the client.
+type httpRange struct {
+	start, length int64
+}
+
+func (r httpRange) contentRange(size int64) string {
+	return fmt.Sprintf("bytes %d-%d/%d", r.start, r.start+r.length-1, size)
+}
+
+func (r httpRange) mimeHeader(contentType string, size int64) textproto.MIMEHeader {
+	return textproto.MIMEHeader{
+		"Content-Range": {r.contentRange(size)},
+		"Content-Type":  {contentType},
+	}
+}
+
+// parseRange parses a Range header string as per RFC 7233.
+// errNoOverlap is returned if none of the ranges overlap.
+func parseRange(s string, size int64) ([]httpRange, error) {
+	if s == "" {
+		return nil, nil // header not present
+	}
+	const b = "bytes="
+	if !strings.HasPrefix(s, b) {
+		return nil, errors.New("invalid range")
+	}
+	var ranges []httpRange
+	noOverlap := false
+	for _, ra := range strings.Split(s[len(b):], ",") {
+		ra = textproto.TrimString(ra)
+		if ra == "" {
+			continue
+		}
+		start, end, ok := strings.Cut(ra, "-")
+		if !ok {
+			return nil, errors.New("invalid range")
+		}
+		start, end = textproto.TrimString(start), textproto.TrimString(end)
+		var r httpRange
+		if start == "" {
+			// If no start is specified, end specifies the
+			// range start relative to the end of the file,
+			// and we are dealing with <suffix-length>
+			// which has to be a non-negative integer as per
+			// RFC 7233 Section 2.1 "Byte-Ranges".
+			if end == "" || end[0] == '-' {
+				return nil, errors.New("invalid range")
+			}
+			i, err := strconv.ParseInt(end, 10, 64)
+			if i < 0 || err != nil {
+				return nil, errors.New("invalid range")
+			}
+			if i > size {
+				i = size
+			}
+			r.start = size - i
+			r.length = size - r.start
+		} else {
+			i, err := strconv.ParseInt(start, 10, 64)
+			if err != nil || i < 0 {
+				return nil, errors.New("invalid range")
+			}
+			if i >= size {
+				// If the range begins after the size of the content,
+				// then it does not overlap.
+				noOverlap = true
+				continue
+			}
+			r.start = i
+			if end == "" {
+				// If no end is specified, range extends to end of the file.
+				r.length = size - r.start
+			} else {
+				i, err := strconv.ParseInt(end, 10, 64)
+				if err != nil || r.start > i {
+					return nil, errors.New("invalid range")
+				}
+				if i >= size {
+					i = size - 1
+				}
+				r.length = i - r.start + 1
+			}
+		}
+		ranges = append(ranges, r)
+	}
+	if noOverlap && len(ranges) == 0 {
+		// The specified ranges did not overlap with the content.
+		return nil, errNoOverlap
+	}
+	return ranges, nil
+}

--- a/internal/http_cache/ghacache/httprange/httprange.go
+++ b/internal/http_cache/ghacache/httprange/httprange.go
@@ -1,4 +1,4 @@
-// parseRange() parsing function from Golang's source code tree (src/net/http/fs.go).
+// ParseRange() parsing function from Golang's source code tree (src/net/http/fs.go).
 //
 // Copyright 2009 The Go Authors. All rights reserved.
 //
@@ -38,29 +38,29 @@ import (
 	"strings"
 )
 
-// errNoOverlap is returned by serveContent's parseRange if first-byte-pos of
+// errNoOverlap is returned by serveContent's ParseRange if first-byte-pos of
 // all of the byte-range-spec values is greater than the content size.
 var errNoOverlap = errors.New("invalid range: failed to overlap")
 
-// httpRange specifies the byte range to be sent to the client.
-type httpRange struct {
-	start, length int64
+// HTTPRange specifies the byte range to be sent to the client.
+type HTTPRange struct {
+	Start, Length int64
 }
 
-func (r httpRange) contentRange(size int64) string {
-	return fmt.Sprintf("bytes %d-%d/%d", r.start, r.start+r.length-1, size)
+func (r HTTPRange) contentRange(size int64) string {
+	return fmt.Sprintf("bytes %d-%d/%d", r.Start, r.Start+r.Length-1, size)
 }
 
-func (r httpRange) mimeHeader(contentType string, size int64) textproto.MIMEHeader {
+func (r HTTPRange) mimeHeader(contentType string, size int64) textproto.MIMEHeader {
 	return textproto.MIMEHeader{
 		"Content-Range": {r.contentRange(size)},
 		"Content-Type":  {contentType},
 	}
 }
 
-// parseRange parses a Range header string as per RFC 7233.
+// ParseRange parses a Range header string as per RFC 7233.
 // errNoOverlap is returned if none of the ranges overlap.
-func parseRange(s string, size int64) ([]httpRange, error) {
+func ParseRange(s string, size int64) ([]HTTPRange, error) {
 	if s == "" {
 		return nil, nil // header not present
 	}
@@ -84,7 +84,7 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 		s = before
 	}
 
-	var ranges []httpRange
+	var ranges []HTTPRange
 	noOverlap := false
 	for _, ra := range strings.Split(s, ",") {
 		ra = textproto.TrimString(ra)
@@ -96,7 +96,7 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 			return nil, errors.New("invalid range")
 		}
 		start, end = textproto.TrimString(start), textproto.TrimString(end)
-		var r httpRange
+		var r HTTPRange
 		if start == "" {
 			// If no start is specified, end specifies the
 			// range start relative to the end of the file,
@@ -113,8 +113,8 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 			if i > size {
 				i = size
 			}
-			r.start = size - i
-			r.length = size - r.start
+			r.Start = size - i
+			r.Length = size - r.Start
 		} else {
 			i, err := strconv.ParseInt(start, 10, 64)
 			if err != nil || i < 0 {
@@ -126,19 +126,19 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 				noOverlap = true
 				continue
 			}
-			r.start = i
+			r.Start = i
 			if end == "" {
 				// If no end is specified, range extends to end of the file.
-				r.length = size - r.start
+				r.Length = size - r.Start
 			} else {
 				i, err := strconv.ParseInt(end, 10, 64)
-				if err != nil || r.start > i {
+				if err != nil || r.Start > i {
 					return nil, errors.New("invalid range")
 				}
 				if i >= size {
 					i = size - 1
 				}
-				r.length = i - r.start + 1
+				r.Length = i - r.Start + 1
 			}
 		}
 		ranges = append(ranges, r)

--- a/internal/http_cache/ghacache/httprange/httprange_test.go
+++ b/internal/http_cache/ghacache/httprange/httprange_test.go
@@ -1,0 +1,105 @@
+// parseRange() test from Golang's source code tree (src/net/http/range_test.go).
+//
+// Copyright 2011 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package httprange
+
+import (
+	"testing"
+)
+
+var ParseRangeTests = []struct {
+	s      string
+	length int64
+	r      []httpRange
+}{
+	{"", 0, nil},
+	{"", 1000, nil},
+	{"foo", 0, nil},
+	{"bytes=", 0, nil},
+	{"bytes=7", 10, nil},
+	{"bytes= 7 ", 10, nil},
+	{"bytes=1-", 0, nil},
+	{"bytes=5-4", 10, nil},
+	{"bytes=0-2,5-4", 10, nil},
+	{"bytes=2-5,4-3", 10, nil},
+	{"bytes=--5,4--3", 10, nil},
+	{"bytes=A-", 10, nil},
+	{"bytes=A- ", 10, nil},
+	{"bytes=A-Z", 10, nil},
+	{"bytes= -Z", 10, nil},
+	{"bytes=5-Z", 10, nil},
+	{"bytes=Ran-dom, garbage", 10, nil},
+	{"bytes=0x01-0x02", 10, nil},
+	{"bytes=         ", 10, nil},
+	{"bytes= , , ,   ", 10, nil},
+
+	{"bytes=0-9", 10, []httpRange{{0, 10}}},
+	{"bytes=0-", 10, []httpRange{{0, 10}}},
+	{"bytes=5-", 10, []httpRange{{5, 5}}},
+	{"bytes=0-20", 10, []httpRange{{0, 10}}},
+	{"bytes=15-,0-5", 10, []httpRange{{0, 6}}},
+	{"bytes=1-2,5-", 10, []httpRange{{1, 2}, {5, 5}}},
+	{"bytes=-2 , 7-", 11, []httpRange{{9, 2}, {7, 4}}},
+	{"bytes=0-0 ,2-2, 7-", 11, []httpRange{{0, 1}, {2, 1}, {7, 4}}},
+	{"bytes=-5", 10, []httpRange{{5, 5}}},
+	{"bytes=-15", 10, []httpRange{{0, 10}}},
+	{"bytes=0-499", 10000, []httpRange{{0, 500}}},
+	{"bytes=500-999", 10000, []httpRange{{500, 500}}},
+	{"bytes=-500", 10000, []httpRange{{9500, 500}}},
+	{"bytes=9500-", 10000, []httpRange{{9500, 500}}},
+	{"bytes=0-0,-1", 10000, []httpRange{{0, 1}, {9999, 1}}},
+	{"bytes=500-600,601-999", 10000, []httpRange{{500, 101}, {601, 399}}},
+	{"bytes=500-700,601-999", 10000, []httpRange{{500, 201}, {601, 399}}},
+
+	// Match Apache laxity:
+	{"bytes=   1 -2   ,  4- 5, 7 - 8 , ,,", 11, []httpRange{{1, 2}, {4, 2}, {7, 2}}},
+}
+
+func TestParseRange(t *testing.T) {
+	for _, test := range ParseRangeTests {
+		r := test.r
+		ranges, err := parseRange(test.s, test.length)
+		if err != nil && r != nil {
+			t.Errorf("parseRange(%q) returned error %q", test.s, err)
+		}
+		if len(ranges) != len(r) {
+			t.Errorf("len(parseRange(%q)) = %d, want %d", test.s, len(ranges), len(r))
+			continue
+		}
+		for i := range r {
+			if ranges[i].start != r[i].start {
+				t.Errorf("parseRange(%q)[%d].start = %d, want %d", test.s, i, ranges[i].start, r[i].start)
+			}
+			if ranges[i].length != r[i].length {
+				t.Errorf("parseRange(%q)[%d].length = %d, want %d", test.s, i, ranges[i].length, r[i].length)
+			}
+		}
+	}
+}

--- a/internal/http_cache/ghacache/httprange/httprange_test.go
+++ b/internal/http_cache/ghacache/httprange/httprange_test.go
@@ -1,4 +1,4 @@
-// parseRange() test from Golang's source code tree (src/net/http/range_test.go).
+// ParseRange() test from Golang's source code tree (src/net/http/range_test.go).
 //
 // Copyright 2011 The Go Authors. All rights reserved.
 //
@@ -38,7 +38,7 @@ import (
 var ParseRangeTests = []struct {
 	s      string
 	length int64
-	r      []httpRange
+	r      []HTTPRange
 }{
 	{"", 0, nil},
 	{"", 1000, nil},
@@ -61,26 +61,26 @@ var ParseRangeTests = []struct {
 	{"bytes=         ", 10, nil},
 	{"bytes= , , ,   ", 10, nil},
 
-	{"bytes=0-9", 10, []httpRange{{0, 10}}},
-	{"bytes=0-", 10, []httpRange{{0, 10}}},
-	{"bytes=5-", 10, []httpRange{{5, 5}}},
-	{"bytes=0-20", 10, []httpRange{{0, 10}}},
-	{"bytes=15-,0-5", 10, []httpRange{{0, 6}}},
-	{"bytes=1-2,5-", 10, []httpRange{{1, 2}, {5, 5}}},
-	{"bytes=-2 , 7-", 11, []httpRange{{9, 2}, {7, 4}}},
-	{"bytes=0-0 ,2-2, 7-", 11, []httpRange{{0, 1}, {2, 1}, {7, 4}}},
-	{"bytes=-5", 10, []httpRange{{5, 5}}},
-	{"bytes=-15", 10, []httpRange{{0, 10}}},
-	{"bytes=0-499", 10000, []httpRange{{0, 500}}},
-	{"bytes=500-999", 10000, []httpRange{{500, 500}}},
-	{"bytes=-500", 10000, []httpRange{{9500, 500}}},
-	{"bytes=9500-", 10000, []httpRange{{9500, 500}}},
-	{"bytes=0-0,-1", 10000, []httpRange{{0, 1}, {9999, 1}}},
-	{"bytes=500-600,601-999", 10000, []httpRange{{500, 101}, {601, 399}}},
-	{"bytes=500-700,601-999", 10000, []httpRange{{500, 201}, {601, 399}}},
+	{"bytes=0-9", 10, []HTTPRange{{0, 10}}},
+	{"bytes=0-", 10, []HTTPRange{{0, 10}}},
+	{"bytes=5-", 10, []HTTPRange{{5, 5}}},
+	{"bytes=0-20", 10, []HTTPRange{{0, 10}}},
+	{"bytes=15-,0-5", 10, []HTTPRange{{0, 6}}},
+	{"bytes=1-2,5-", 10, []HTTPRange{{1, 2}, {5, 5}}},
+	{"bytes=-2 , 7-", 11, []HTTPRange{{9, 2}, {7, 4}}},
+	{"bytes=0-0 ,2-2, 7-", 11, []HTTPRange{{0, 1}, {2, 1}, {7, 4}}},
+	{"bytes=-5", 10, []HTTPRange{{5, 5}}},
+	{"bytes=-15", 10, []HTTPRange{{0, 10}}},
+	{"bytes=0-499", 10000, []HTTPRange{{0, 500}}},
+	{"bytes=500-999", 10000, []HTTPRange{{500, 500}}},
+	{"bytes=-500", 10000, []HTTPRange{{9500, 500}}},
+	{"bytes=9500-", 10000, []HTTPRange{{9500, 500}}},
+	{"bytes=0-0,-1", 10000, []HTTPRange{{0, 1}, {9999, 1}}},
+	{"bytes=500-600,601-999", 10000, []HTTPRange{{500, 101}, {601, 399}}},
+	{"bytes=500-700,601-999", 10000, []HTTPRange{{500, 201}, {601, 399}}},
 
 	// Match Apache laxity:
-	{"bytes=   1 -2   ,  4- 5, 7 - 8 , ,,", 11, []httpRange{{1, 2}, {4, 2}, {7, 2}}},
+	{"bytes=   1 -2   ,  4- 5, 7 - 8 , ,,", 11, []HTTPRange{{1, 2}, {4, 2}, {7, 2}}},
 
 	// Ensure support of RFC 7233-style Content-Range headers[1]:
 	//
@@ -88,27 +88,27 @@ var ParseRangeTests = []struct {
 	// * complete length specifier after "/"
 	//
 	// [1]: https://datatracker.ietf.org/doc/html/rfc7233#section-4.2
-	{"bytes 0-33554431/*", math.MaxInt64, []httpRange{{0, 33554432}}},
-	{"bytes 33554432-49336508/*", math.MaxInt64, []httpRange{{33554432, 15782077}}},
+	{"bytes 0-33554431/*", math.MaxInt64, []HTTPRange{{0, 33554432}}},
+	{"bytes 33554432-49336508/*", math.MaxInt64, []HTTPRange{{33554432, 15782077}}},
 }
 
 func TestParseRange(t *testing.T) {
 	for _, test := range ParseRangeTests {
 		r := test.r
-		ranges, err := parseRange(test.s, test.length)
+		ranges, err := ParseRange(test.s, test.length)
 		if err != nil && r != nil {
-			t.Errorf("parseRange(%q) returned error %q", test.s, err)
+			t.Errorf("ParseRange(%q) returned error %q", test.s, err)
 		}
 		if len(ranges) != len(r) {
-			t.Errorf("len(parseRange(%q)) = %d, want %d", test.s, len(ranges), len(r))
+			t.Errorf("len(ParseRange(%q)) = %d, want %d", test.s, len(ranges), len(r))
 			continue
 		}
 		for i := range r {
-			if ranges[i].start != r[i].start {
-				t.Errorf("parseRange(%q)[%d].start = %d, want %d", test.s, i, ranges[i].start, r[i].start)
+			if ranges[i].Start != r[i].Start {
+				t.Errorf("ParseRange(%q)[%d].Start = %d, want %d", test.s, i, ranges[i].Start, r[i].Start)
 			}
-			if ranges[i].length != r[i].length {
-				t.Errorf("parseRange(%q)[%d].length = %d, want %d", test.s, i, ranges[i].length, r[i].length)
+			if ranges[i].Length != r[i].Length {
+				t.Errorf("ParseRange(%q)[%d].Length = %d, want %d", test.s, i, ranges[i].Length, r[i].Length)
 			}
 		}
 	}

--- a/internal/http_cache/ghacache/httprange/httprange_test.go
+++ b/internal/http_cache/ghacache/httprange/httprange_test.go
@@ -31,6 +31,7 @@
 package httprange
 
 import (
+	"math"
 	"testing"
 )
 
@@ -80,6 +81,15 @@ var ParseRangeTests = []struct {
 
 	// Match Apache laxity:
 	{"bytes=   1 -2   ,  4- 5, 7 - 8 , ,,", 11, []httpRange{{1, 2}, {4, 2}, {7, 2}}},
+
+	// Ensure support of RFC 7233-style Content-Range headers[1]:
+	//
+	// * "bytes " instead of "bytes="
+	// * complete length specifier after "/"
+	//
+	// [1]: https://datatracker.ietf.org/doc/html/rfc7233#section-4.2
+	{"bytes 0-33554431/*", math.MaxInt64, []httpRange{{0, 33554432}}},
+	{"bytes 33554432-49336508/*", math.MaxInt64, []httpRange{{33554432, 15782077}}},
 }
 
 func TestParseRange(t *testing.T) {

--- a/internal/http_cache/ghacache/uploadable/uploadable.go
+++ b/internal/http_cache/ghacache/uploadable/uploadable.go
@@ -1,0 +1,86 @@
+package uploadable
+
+import (
+	"fmt"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/http_cache/ghacache/httprange"
+	"io"
+	"math"
+	"os"
+	"sync"
+)
+
+type Uploadable struct {
+	Key     string
+	Version string
+
+	file      *os.File
+	finalized bool
+	mtx       sync.Mutex
+}
+
+func New(key string, version string) (*Uploadable, error) {
+	file, err := os.CreateTemp("", "")
+	if err != nil {
+		return nil, err
+	}
+
+	_ = os.Remove(file.Name())
+
+	return &Uploadable{
+		Key:     key,
+		Version: version,
+		file:    file,
+	}, nil
+}
+
+func (uploadable *Uploadable) WriteChunk(contentRange string, buf []byte) error {
+	uploadable.mtx.Lock()
+	defer uploadable.mtx.Unlock()
+
+	if uploadable.finalized {
+		return fmt.Errorf("cannot write a chunk to a finalized uploadable")
+	}
+
+	httpRanges, err := httprange.ParseRange(contentRange, math.MaxInt64)
+	if err != nil {
+		return fmt.Errorf("failed to parse Content-Range header: %w", err)
+	}
+
+	if len(httpRanges) != 1 {
+		return fmt.Errorf("expected a single range in the \"Content-Range\" header, "+
+			"got %d ranges instead", len(httpRanges))
+	}
+
+	_, err = uploadable.file.WriteAt(buf, httpRanges[0].Start)
+	if err != nil {
+		return fmt.Errorf("failed to write the chunk to a file associated "+
+			"with this uploadable: %w", err)
+	}
+
+	return nil
+}
+
+func (uploadable *Uploadable) Finalize() (io.ReadCloser, int64, error) {
+	uploadable.mtx.Lock()
+	defer uploadable.mtx.Unlock()
+
+	if uploadable.finalized {
+		return nil, 0, fmt.Errorf("cannot finalize the uploadable twice")
+	}
+
+	// Determine the file size (needed for the consumer)
+	size, err := uploadable.file.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Rewind the file
+	if _, err := uploadable.file.Seek(0, io.SeekStart); err != nil {
+		return nil, 0, err
+	}
+
+	// Mark the uploadable as finalized
+	uploadable.finalized = true
+
+	return uploadable.file, size, nil
+}

--- a/internal/http_cache/ghacache/uploadable/uploadable_test.go
+++ b/internal/http_cache/ghacache/uploadable/uploadable_test.go
@@ -1,0 +1,30 @@
+package uploadable_test
+
+import (
+	"fmt"
+	"github.com/cirruslabs/cirrus-ci-agent/internal/http_cache/ghacache/uploadable"
+	"github.com/stretchr/testify/require"
+	"io"
+	"testing"
+)
+
+func TestSimple(t *testing.T) {
+	uploadable, err := uploadable.New("hello", "1")
+	require.NoError(t, err)
+
+	const part1 = "Hello, "
+	const part2 = "World!"
+
+	require.NoError(t, uploadable.WriteChunk(fmt.Sprintf("bytes %d-%d/*",
+		0, len(part1)), []byte(part1)))
+	require.NoError(t, uploadable.WriteChunk(fmt.Sprintf("bytes %d-%d/*",
+		len(part1), len(part1+part2)), []byte(part2)))
+
+	reader, size, err := uploadable.Finalize()
+	require.NoError(t, err)
+	require.EqualValues(t, len(part1+part2), size)
+
+	buf, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, part1+part2, string(buf))
+}


### PR DESCRIPTION
It turns out that the GHA cache protocol writes chunks in parallel using the `Content-Range` headers.

This change adds a support for this and also stores everything in temporary files which are `unlink(2)`'ed at creation.

This PR also correctly returns JSON for all GHA cache response, even for error ones, which [`go-actions-cache` expects](https://github.com/tonistiigi/go-actions-cache/blob/6c9ed76faed5bcb5ffd114720936a166d5f58091/cache.go#L613-L615).