### PR TITLE
ghacache: HTTP 200 is also a good status

### DIFF
--- a/internal/http_cache/ghacache/ghacache.go
+++ b/internal/http_cache/ghacache/ghacache.go
@@ -206,7 +206,7 @@ func (cache *GHACache) commitUploadable(writer http.ResponseWriter, request *htt
 		return
 	}
 
-	if resp.StatusCode != http.StatusCreated {
+	if !(resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated) {
 		fail(writer, request, http.StatusInternalServerError, "GHA cache failed to "+
 			"upload the uploadable with ID %d: got HTTP %d", id, resp.StatusCode)
 


### PR DESCRIPTION
In the cloud, a different code-path in the agent's HTTP cache kicks that replies with HTTP 200 instead of HTTP 201 for a successful cache upload. Handle that.

See https://cirrus-ci.com/task/6204584780103680?logs=build#L289 for more details.