### PR TITLE
GHA cache: do not generate cache IDs larger than JavaScript can support

### DIFF
--- a/internal/http_cache/ghacache/ghacache.go
+++ b/internal/http_cache/ghacache/ghacache.go
@@ -14,7 +14,14 @@ import (
 	"strings"
 )
 
-const APIMountPoint = "/_apis/artifactcache"
+const (
+	APIMountPoint = "/_apis/artifactcache"
+
+	// JavaScript's Number is limited to 2^53-1[1]
+	//
+	// [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+	jsNumberMaxSafeInteger = 9007199254740991
+)
 
 type GHACache struct {
 	cacheHost   string
@@ -98,7 +105,7 @@ func (cache *GHACache) reserveUploadable(writer http.ResponseWriter, request *ht
 	jsonResp := struct {
 		CacheID int64 `json:"cacheId"`
 	}{
-		CacheID: rand.Int63(),
+		CacheID: rand.Int63n(jsNumberMaxSafeInteger),
 	}
 
 	uploadable, err := uploadable.New(jsonReq.Key, jsonReq.Version)


### PR DESCRIPTION
Found this while testing the https://github.com/actions/cache with the following patch:

```js
const httpCacheHost = process.env["CIRRUS_HTTP_CACHE_HOST"];

if (httpCacheHost != null) {
    const newActionsCacheURL = `http://${httpCacheHost}/`;

    console.log(`Re-defining ACTIONS_CACHE_URL to ${newActionsCacheURL}`);

    process.env["ACTIONS_CACHE_URL"] = newActionsCacheURL;
}
```