### PR TITLE
Return 404 on prefix matching instead of 400

### DIFF
--- a/internal/http_cache/ghacache/ghacache.go
+++ b/internal/http_cache/ghacache/ghacache.go
@@ -80,7 +80,7 @@ func (cache *GHACache) get(writer http.ResponseWriter, request *http.Request) {
 	// The rest of the keys are used for prefix matching
 	// (fallback mechanism) which we do not support
 	if len(keys[1:]) != 0 {
-		fail(writer, request, http.StatusBadRequest, "GHA cache does not support prefix "+
+		fail(writer, request, http.StatusNotFound, "GHA cache does not support prefix "+
 			"matching, was needed for (%v, %v)", keys, version)
 
 		return


### PR DESCRIPTION
Othervise there are warning like this:

![image](https://github.com/cirruslabs/cirrus-ci-agent/assets/989066/c0b8577c-e1e2-47a4-9c33-5473f1410dde)
