### PR TITLE
Don't hide cancellation reason

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -209,6 +209,7 @@ func main() {
 			sig := <-signalChannel
 
 			if sig == os.Interrupt || sig == syscall.SIGTERM {
+				log.Printf("execution canceled by '%v' signal!", sig)
 				cancel()
 			}
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -52,6 +52,7 @@ type StepResult struct {
 
 var (
 	ErrStepExit = errors.New("executor step requested to terminate execution")
+	ErrTimedOut = errors.New("timed out")
 )
 
 func NewExecutor(
@@ -215,7 +216,7 @@ func (executor *Executor) RunBuild(ctx context.Context) {
 	// Normal timeout-bounded context
 	timeout := time.Duration(response.TimeoutInSeconds) * time.Second
 
-	timeoutCtx, timeoutCtxCancel := context.WithTimeout(ctx, timeout)
+	timeoutCtx, timeoutCtxCancel := context.WithTimeoutCause(ctx, timeout, ErrTimedOut)
 	defer timeoutCtxCancel()
 
 	// Like timeout-bounded context, but extended by 5 minutes
@@ -500,7 +501,7 @@ func (executor *Executor) performStep(ctx context.Context, currentStep *api.Comm
 				signaledToExit = ws.Signaled()
 			}
 		}
-		if err == TimeOutError {
+		if err == ErrTimedOut {
 			signaledToExit = false
 		}
 	case *api.Command_BackgroundScriptInstruction:

--- a/internal/executor/shell.go
+++ b/internal/executor/shell.go
@@ -23,8 +23,6 @@ type ShellOutputWriter struct {
 	handler ShellOutputHandler
 }
 
-var TimeOutError = errors.New("timed out")
-
 func (writer ShellOutputWriter) Write(bytes []byte) (int, error) {
 	return writer.handler(bytes)
 }
@@ -61,7 +59,7 @@ func ShellCommandsAndWait(
 
 	select {
 	case <-ctx.Done():
-		handler([]byte("\nTimed out!"))
+		handler([]byte(fmt.Sprintf("\ninterrupted: %v", ctx.Err())))
 
 		processdumper.Dump()
 
@@ -69,7 +67,7 @@ func ShellCommandsAndWait(
 			handler([]byte(fmt.Sprintf("\nFailed to kill a timed out shell session: %s", err)))
 		}
 
-		return cmd, TimeOutError
+		return cmd, ctx.Err()
 	case <-done:
 		var forcePiperClosure bool
 

--- a/internal/executor/shell_subunix_test.go
+++ b/internal/executor/shell_subunix_test.go
@@ -16,13 +16,13 @@ import (
 // the shell spawned in ShellCommandsAndGetOutput() has been placed into, thus killing
 // it's children processes.
 func TestProcessGroupTermination(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeoutCause(context.Background(), 1*time.Second, ErrTimedOut)
 	defer cancel()
 
 	success, output := ShellCommandsAndGetOutput(ctx, []string{"sleep 86400 & echo target PID is $! ; sleep 60"}, nil)
 
 	assert.False(t, success, "the command should fail due to time out error")
-	assert.Contains(t, output, "Timed out!", "the command should time out")
+	assert.Contains(t, output, "timed out", "the command should time out")
 
 	re := regexp.MustCompile(".*target PID is ([0-9]+).*")
 	matches := re.FindStringSubmatch(output)

--- a/internal/executor/shell_unix_test.go
+++ b/internal/executor/shell_unix_test.go
@@ -116,7 +116,7 @@ func Test_ShellCommands_Timeout_Unix(t *testing.T) {
 	defer cancel()
 
 	_, output := ShellCommandsAndGetOutput(ctx, []string{"sleep 60"}, nil)
-	if output == "sleep 60\n\nTimed out!" {
+	if output == "sleep 60\n\ninterrupted: timed out" {
 		t.Log("Passed")
 	} else {
 		t.Errorf("Wrong output: '%s'", output)
@@ -130,7 +130,7 @@ func TestChildrenProcessesAreCancelled(t *testing.T) {
 	success, output := ShellCommandsAndGetOutput(ctx, []string{"sleep 60 & sleep 10"}, nil)
 
 	assert.False(t, success)
-	assert.Contains(t, output, "Timed out!")
+	assert.Contains(t, output, "timed out")
 }
 
 func TestChildrenProcessesAreNotWaitedFor(t *testing.T) {
@@ -143,7 +143,7 @@ func TestChildrenProcessesAreNotWaitedFor(t *testing.T) {
 	}
 
 	assert.True(t, success)
-	assert.NotContains(t, output, "Timed out!")
+	assert.NotContains(t, output, "timed out")
 }
 
 func TestShellStartFailureDoesNotHang(t *testing.T) {

--- a/internal/executor/shell_windows_test.go
+++ b/internal/executor/shell_windows_test.go
@@ -53,14 +53,14 @@ func TestMain(m *testing.M) {
 // TestProcessGroupTermination ensures that we terminate all processes we've automatically
 // tainted by assigning a job object to a shell spawned in ShellCommandsAndGetOutput().
 func TestJobObjectTermination(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeoutCause(context.Background(), 10*time.Second, ErrTimedOut)
 	defer cancel()
 
 	success, output := ShellCommandsAndGetOutput(ctx, []string{os.Args[0]},
 		environment.New(map[string]string{"MODE": modeProcessTreeSpawner}))
 
 	assert.False(t, success, "the command should fail due to time out error")
-	assert.Contains(t, output, "Timed out!", "the command should time out")
+	assert.Contains(t, output, "timed out", "the command should time out")
 
 	re := regexp.MustCompile(".*target PID is ([0-9]+).*")
 	matches := re.FindStringSubmatch(output)


### PR DESCRIPTION
Otherwise, we assume a task has timeout when in reality it could've been externally interrupted.