### PR TITLE
Prepare agent repository for archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**NOTE**: The agent now resides in the [Cirrus CLI's repository](https://github.com/cirruslabs/cirrus-cli) and can be invoked as `cirrus agent`.
+
 # Agent to execute Cirrus CI tasks
 
 [![Build Status](https://api.cirrus-ci.com/github/cirruslabs/cirrus-ci-agent.svg)](https://cirrus-ci.com/github/cirruslabs/cirrus-ci-agent)


### PR DESCRIPTION
Because we've moved the agent to the [Cirrus CLI's repository](https://github.com/cirruslabs/cirrus-cli) not too long ago.